### PR TITLE
feat: import docs from ministry-of-justice-developer-portal

### DIFF
--- a/source/documentation/portal content management/spec-community.md
+++ b/source/documentation/portal content management/spec-community.md
@@ -1,0 +1,112 @@
+# Community Template Contract
+
+Status: Draft v1  
+Owner: Developer Experience  
+Applies to: Community landing and detail pages under `/community`.
+
+## Purpose
+
+Community content should answer:
+
+- where to connect with other teams
+- what kind of community resource this is
+- who owns it
+- whether it is ongoing or date-based
+
+## Current implementation in this repo
+
+Community content currently lives in `content/community/community.json`.
+
+It is rendered by:
+
+- `app/community/page.tsx` for the landing page
+- `app/community/[slug]/page.tsx` for item detail pages
+
+The current file contains both:
+
+- top-level landing-page content such as `title`, `summary`, `supportingSections`, and `contribution`
+- detail items under `items[]`
+
+This makes Community structurally similar to Products, but with extra landing-page support content and event-specific fields.
+
+## Current item model
+
+Current item fields are:
+
+- `slug`
+- `title`
+- `category`
+- `description`
+- `owner`
+- `status`
+- `tags`
+- `sections`
+- optional `primaryLinks`
+- optional `eventDate`
+- optional `endDate`
+- optional `location`
+- optional `isRecurring`
+
+## Target page contract
+
+Required sections:
+
+1. Header: title, category, summary, owner, status
+2. Body: one or more sections explaining the resource
+3. Metadata: owner, status, tags, and event details when relevant
+4. Links: primary actions where useful
+
+Optional sections:
+
+- event timing and location
+- recurring schedule information
+- supporting landing-page resources
+- contribution callout
+- feedback prompt
+
+## Target metadata model
+
+Required for detail items:
+
+- `slug` (string)
+- `title` (string)
+- `category` (string)
+- `description` (string)
+- `owner` (string)
+- `status` (string)
+- `tags` (string array)
+- `sections` (array)
+
+Recommended:
+
+- `primaryLinks` (array)
+- `eventDate` (ISO date, event items)
+- `endDate` (ISO date, event items)
+- `location` (string, event items)
+- `isRecurring` (boolean, event items)
+- `pageType` (`community`)
+
+## Content guidance
+
+Do:
+
+- make the purpose of the item obvious
+- keep item types flexible
+- add concrete next actions when they exist
+- treat event metadata as required for scheduled events
+
+Do not:
+
+- force every item into an event shape
+- publish vague entries with no reason to engage
+- mix landing-page support content into item fields
+
+## MVP
+
+The minimum useful community item is:
+
+- title, category, description, owner, status
+- tags
+- one content section
+
+If the item is an event, add at least the event date and location.

--- a/source/documentation/portal content management/spec-documentation.md
+++ b/source/documentation/portal content management/spec-documentation.md
@@ -1,0 +1,118 @@
+# Documentation Template Contract
+
+Status: Draft v1  
+Owner: Developer Experience  
+Applies to: Generated documentation shown under `/docs`.
+
+## Purpose
+
+Documentation pages should help users understand:
+
+- how to do a task
+- where the content came from
+- where they are in the docs tree
+- how fresh the content is, when that metadata exists
+
+## Current implementation in this repo
+
+The Documentation section is generated content, not hand-authored route content.
+
+Current flow:
+
+1. `sources.json` declares external documentation sources.
+2. `scripts/ingest.mjs` clones and converts those sources.
+3. Generated files are written to `content/docs/<source-id>/`.
+4. `lib/docs.ts` loads that output for `app/docs/page.tsx` and `app/docs/[...slug]/page.tsx`.
+
+Because of that, `content/docs/` may not exist until `npm run ingest` has been run.
+
+## Current metadata model
+
+Current page-level metadata is inconsistent by source.
+
+Common page fields:
+
+- `title`
+- optional `lastReviewedOn` or `last_reviewed_on`
+- optional `reviewIn` or `review_in`
+- optional `ownerSlack` or `owner_slack`
+- optional `sourceRepo` or `source_repo`
+- optional `sourcePath` or `source_path`
+- optional `ingestedAt` or `ingested_at`
+- optional `weight`
+
+Current source-level metadata in `_meta.json` typically includes:
+
+- `name`
+- `description`
+- `category`
+- `source_repo`
+- `ingested_at`
+
+## Target page contract
+
+Required sections:
+
+1. Header: page title, plus source context on landing pages where useful
+2. Navigation: breadcrumbs and source or section navigation
+3. Body: rendered markdown content
+4. Metadata: review and provenance details when available
+
+Optional sections:
+
+- summary or intro
+- related pages
+- source description on landing pages
+- callouts and warnings
+- feedback prompt
+
+## Target standardisation goals
+
+- use one metadata naming convention, ideally camelCase
+- introduce a first-class summary field if intros should be standard
+- keep source-level and page-level metadata distinct
+- only add `primaryLinks[]` if docs pages need explicit actions beyond markdown links
+
+## Content guidance
+
+Do:
+
+- keep the external repo as source of truth where appropriate
+- preserve navigation structure
+- expose provenance when available
+- degrade gracefully when metadata is sparse
+
+Do not:
+
+- assume every page has a summary
+- treat generated docs like hand-authored CMS content
+- merge source metadata and page metadata into one flat contract
+
+## MVP
+
+The minimum useful documentation page is:
+
+- title
+- markdown body
+- navigation context
+
+Review, owner, and source metadata should appear when available, but they are not universal today.
+
+## Operations
+
+Useful commands:
+
+```bash
+npm run ingest
+npm run ingest:dry-run
+node scripts/ingest.mjs cloud-platform
+npm run ingest:build
+```
+
+Adding a source:
+
+1. Add it to `sources.json`.
+2. Run `npm run ingest:dry-run`.
+3. Run `npm run ingest`.
+4. Confirm output under `content/docs/<source-id>/`.
+5. Confirm it appears on `/docs`.

--- a/source/documentation/portal content management/spec-guidelines.md
+++ b/source/documentation/portal content management/spec-guidelines.md
@@ -1,0 +1,99 @@
+# Guideline Template Contract
+
+Status: Draft v1  
+Owner: Developer Experience  
+Applies to: Guideline and standards pages under `/guidelines`.
+
+## Purpose
+
+Guideline pages should make it clear:
+
+- what the guidance is
+- when it applies
+- who owns it
+- how fresh it is
+- whether this portal is the source of truth or a signpost
+
+## Current implementation in this repo
+
+Guideline metadata currently lives in `content/guidelines/guidelines.json`.
+
+The detail route is rendered by `app/guidelines/[slug]/page.tsx`.
+
+Today the repo splits guideline data in two ways:
+
+- structured metadata in `guidelines.json`
+- page body content inline in `app/guidelines/[slug]/page.tsx`
+
+That means the metadata contract is fairly stable, but the body-content model is still transitional.
+
+## Current metadata model
+
+Current fields in `guidelines.json` are:
+
+- `slug`
+- `title`
+- `phase`
+- `description`
+- `owner`
+- `lastReviewedOn`
+- `reviewIn`
+- optional `externalUrl`
+
+## Target page contract
+
+Required sections:
+
+1. Header: title, phase, summary, owner
+2. Guidance body: the standard or expectation itself
+3. Metadata: last reviewed, review cadence, review status, owner
+
+Optional sections:
+
+- external canonical link
+- related links
+- examples and anti-patterns
+- decision steps
+- compliance references
+- feedback prompt
+
+## Target metadata model
+
+Required:
+
+- `slug` (string)
+- `title` (string)
+- `phase` (string)
+- `description` (string)
+- `owner` (string)
+- `lastReviewedOn` (ISO date)
+- `reviewIn` (for example `6 months`)
+
+Recommended:
+
+- `externalUrl` (string)
+- `tags` (string array)
+- `pageType` (`guideline`)
+
+## Content guidance
+
+Do:
+
+- explain the rule and why it exists
+- make the lifecycle phase explicit
+- show review metadata
+- link out when another source is canonical
+
+Do not:
+
+- mix unrelated guidance on one page
+- publish without an owner
+- duplicate large external guidance without a good reason
+
+## MVP
+
+The minimum useful guideline page is:
+
+- title, phase, summary, owner
+- one clear guidance section
+- last reviewed date and owner metadata

--- a/source/documentation/portal content management/spec-products.md
+++ b/source/documentation/portal content management/spec-products.md
@@ -1,0 +1,106 @@
+# Product Template Contract
+
+Status: Draft v1  
+Owner: Developer Experience  
+Applies to: Product and service detail pages under `/products`.
+
+## Purpose
+
+Product pages should answer four questions quickly:
+
+- What is this product?
+- Who is it for?
+- Who owns it?
+- Where should I go next?
+
+## Current implementation in this repo
+
+Products are currently defined in `content/products/products.json` and rendered by:
+
+- `app/products/page.tsx` for the index
+- `app/products/[slug]/page.tsx` for the detail page
+
+Current live fields in `products.json` are:
+
+- `slug`
+- `name`
+- `category`
+- `description`
+- `owner`
+- `status`
+- `tags`
+- optional `slackChannel`
+- optional `docsUrl`
+- optional `externalUrl`
+
+Current field mapping to the target contract:
+
+- `name` -> `title`
+- `description` -> `summary`
+- `docsUrl` and `externalUrl` -> `primaryLinks[]`
+- `slackChannel` -> `supportChannel`
+
+This matters because contributors update `products.json` today, even though the longer-term contract below uses more consistent names.
+
+## Target page contract
+
+Required sections:
+
+1. Header: title, category, status, owner, summary
+2. Core details: what it does, who should use it, scope
+3. Primary actions: at least one next step
+4. Metadata: owner, status, review information when available
+
+Optional sections:
+
+- Slack or support channel
+- Tags
+- Usage examples
+- Limitations
+- Security or compliance notes
+- Related products
+- Feedback prompt
+
+## Target metadata model
+
+Required:
+
+- `slug` (string)
+- `title` (string)
+- `summary` (string)
+- `category` (string)
+- `owner` (string)
+- `status` (`live` | `beta` | `alpha`)
+- `primaryLinks` (array, at least one item)
+
+Recommended:
+
+- `lastReviewedOn` (ISO date)
+- `reviewIn` (for example `6 months`)
+- `tags` (string array)
+- `supportChannel` (string)
+- `pageType` (`product`)
+
+## Content guidance
+
+Do:
+
+- Use a plain-language summary.
+- Make the next action obvious.
+- Keep ownership specific.
+- Keep status honest.
+
+Do not:
+
+- Turn the page into full documentation.
+- Use vague marketing language.
+- Publish without a useful link.
+
+## MVP
+
+The minimum useful product page is:
+
+- title, category, status, owner, summary
+- one short description section
+- one action link
+- owner and status metadata

--- a/source/runbooks/cloud-platform-deployment-runbook.md
+++ b/source/runbooks/cloud-platform-deployment-runbook.md
@@ -1,0 +1,241 @@
+# Cloud Platform Deployment Runbook
+
+## Review Dates
+
+- Last reviewed: 2026-04-24
+
+## Scope
+
+This runbook covers deployment of `ministryofjustice/ministry-of-justice-developer-portal` to Cloud Platform Kubernetes namespaces:
+
+- `developer-portal-dev`
+- `developer-portal-prod`
+
+It documents required GitHub configuration, deployment flow, and operational kubectl commands.
+
+## Canonical Repository and Workflow Links
+
+- Repository: <https://github.com/ministryofjustice/ministry-of-justice-developer-portal>
+- Dev deploy workflow file: <https://github.com/ministryofjustice/ministry-of-justice-developer-portal/blob/main/.github/workflows/deploy-dev.yml>
+- Prod deploy workflow file: <https://github.com/ministryofjustice/ministry-of-justice-developer-portal/blob/main/.github/workflows/deploy-prod.yml>
+- Smoke test script: <https://github.com/ministryofjustice/ministry-of-justice-developer-portal/blob/main/scripts/smoke-test.sh>
+- Dev k8s manifest: <https://github.com/ministryofjustice/ministry-of-justice-developer-portal/blob/main/k8s/dev/deployment.yaml>
+- Prod k8s manifest: <https://github.com/ministryofjustice/ministry-of-justice-developer-portal/blob/main/k8s/prod/deployment.yaml>
+
+## GitHub Actions Configuration
+
+### Repository Variables (Actions)
+
+Set these at:
+<https://github.com/ministryofjustice/ministry-of-justice-developer-portal/settings/variables/actions>
+
+Required:
+
+- `ECR_REGION`
+- `ECR_REPOSITORY`
+
+### Environment Secrets: Dev
+
+Set these at:
+<https://github.com/ministryofjustice/ministry-of-justice-developer-portal/settings/environments/dev>
+
+Required:
+
+- `DEV_ECR_ROLE_TO_ASSUME`
+- `DEV_KUBE_CLUSTER`
+- `DEV_KUBE_NAMESPACE`
+- `DEV_KUBE_CERT`
+- `DEV_KUBE_TOKEN`
+
+Expected values:
+
+- `DEV_KUBE_NAMESPACE=developer-portal-dev`
+- `DEV_KUBE_CLUSTER` should be the full API server URL (for example `https://...eks.amazonaws.com`)
+- `DEV_KUBE_CERT` should be the PEM CA cert (plain text)
+
+### Environment Secrets: Prod
+
+Set these at:
+<https://github.com/ministryofjustice/ministry-of-justice-developer-portal/settings/environments/prod>
+
+Required:
+
+- `PROD_ECR_ROLE_TO_ASSUME`
+- `PROD_KUBE_CLUSTER`
+- `PROD_KUBE_NAMESPACE`
+- `PROD_KUBE_CERT`
+- `PROD_KUBE_TOKEN`
+
+Expected values:
+
+- `PROD_KUBE_NAMESPACE=developer-portal-prod`
+- `PROD_KUBE_CLUSTER` should be the full API server URL
+- `PROD_KUBE_CERT` should be the PEM CA cert (plain text)
+
+## How To Add A New Environment/Namespace
+
+Use this process for a new environment such as `staging`.
+
+1. Provision namespace access in Cloud Platform for the new namespace (for example `developer-portal-staging`) and obtain:
+
+- cluster API URL
+- cluster CA cert
+- service account token with namespace-scoped deploy permissions
+
+1. Create a GitHub Environment (for example `staging`) at:
+
+<https://github.com/ministryofjustice/ministry-of-justice-developer-portal/settings/environments>
+
+1. Add environment secrets following existing naming conventions:
+
+- `<ENV>_ECR_ROLE_TO_ASSUME`
+- `<ENV>_KUBE_CLUSTER`
+- `<ENV>_KUBE_NAMESPACE`
+- `<ENV>_KUBE_CERT`
+- `<ENV>_KUBE_TOKEN`
+
+1. Add namespace manifests under `k8s/<env>/deployment.yaml` by copying an existing manifest and updating:
+
+- namespace
+- ingress host
+- ingress class
+- external-dns annotations (`aws-weight`, `set-identifier`)
+- TLS secret name
+
+1. Add a deploy workflow (for example `.github/workflows/deploy-<env>.yml`) by copying `deploy-dev.yml` or `deploy-prod.yml` and updating:
+
+- `environment: <env>`
+- secret names to `<ENV>_*`
+- manifest path `k8s/<env>/deployment.yaml`
+- smoke test hostname
+
+1. Run workflow_dispatch for the new workflow and validate:
+
+- rollout success in new namespace
+- ingress created and synced
+- smoke test returns `200` with body `ok`
+
+1. Add operational commands for the new namespace in this runbook once verified.
+
+## Deployment Flow
+
+### Dev Deployment
+
+Trigger options:
+
+- Automatic on push to `main`
+- Manual dispatch at: <https://github.com/ministryofjustice/ministry-of-justice-developer-portal/actions/workflows/deploy-dev.yml>
+
+Execution sequence:
+
+1. Validate required ECR variables/secrets.
+2. Assume AWS role for ECR.
+3. Build and push image to ECR using `docker buildx --platform linux/amd64`.
+4. Configure kubectl context using `DEV_KUBE_*` secrets.
+5. Apply `k8s/dev/deployment.yaml` with image replacement and namespace substitution.
+6. Wait for rollout in `developer-portal-dev`.
+7. Resolve ingress load balancer host to IP.
+8. Run smoke test against `https://dev.developer-portal.service.justice.gov.uk/healthz`.
+
+Note: smoke test uses `curl --resolve` internally to avoid transient DNS failures on GitHub runners.
+
+### Prod Deployment
+
+Trigger:
+
+- Manual dispatch at: <https://github.com/ministryofjustice/ministry-of-justice-developer-portal/actions/workflows/deploy-prod.yml>
+
+Execution sequence:
+
+1. Validate required ECR variables/secrets.
+2. Assume AWS role for ECR.
+3. Build and push image to ECR using `docker buildx --platform linux/amd64`.
+4. Configure kubectl context using `PROD_KUBE_*` secrets.
+5. Apply `k8s/prod/deployment.yaml` with image replacement and namespace substitution.
+6. Wait for rollout in `developer-portal-prod`.
+7. Resolve ingress load balancer host to IP.
+8. Run smoke test against `https://developer-portal.service.justice.gov.uk/healthz`.
+
+## Cloud Platform Namespace Commands
+
+Prerequisites:
+
+- `kubectl` installed
+- kubeconfig/context with access to Cloud Platform cluster
+
+### Context and Namespace Helpers
+
+```bash
+kubectl config get-contexts
+kubectl config current-context
+
+# Optional convenience aliases
+alias kdev='kubectl -n developer-portal-dev'
+alias kprod='kubectl -n developer-portal-prod'
+```
+
+### Dev Namespace (`developer-portal-dev`)
+
+```bash
+kubectl -n developer-portal-dev get deploy,pods,svc,ing
+kubectl -n developer-portal-dev rollout status deployment/developer-portal --timeout=180s
+kubectl -n developer-portal-dev describe ingress developer-portal
+kubectl -n developer-portal-dev get endpoints developer-portal -o wide
+kubectl -n developer-portal-dev logs deployment/developer-portal --tail=100
+```
+
+Ingress direct health check (bypass local DNS):
+
+```bash
+LB=$(kubectl -n developer-portal-dev get ingress developer-portal -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+curl -skI -H 'Host: dev.developer-portal.service.justice.gov.uk' "https://${LB}/healthz"
+```
+
+### Prod Namespace (`developer-portal-prod`)
+
+```bash
+kubectl -n developer-portal-prod get deploy,pods,svc,ing
+kubectl -n developer-portal-prod rollout status deployment/developer-portal --timeout=180s
+kubectl -n developer-portal-prod describe ingress developer-portal
+kubectl -n developer-portal-prod get endpoints developer-portal -o wide
+kubectl -n developer-portal-prod logs deployment/developer-portal --tail=100
+```
+
+Ingress direct health check (bypass local DNS):
+
+```bash
+LB=$(kubectl -n developer-portal-prod get ingress developer-portal -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+curl -skI -H 'Host: developer-portal.service.justice.gov.uk' "https://${LB}/healthz"
+```
+
+## DNS Troubleshooting Quick Checks
+
+```bash
+# Public resolver
+
+dig +short @8.8.8.8 dev.developer-portal.service.justice.gov.uk
+dig +short @8.8.8.8 developer-portal.service.justice.gov.uk
+
+# Local resolver path
+
+dig +short dev.developer-portal.service.justice.gov.uk
+dig +short developer-portal.service.justice.gov.uk
+```
+
+If local resolution fails but ingress host-header checks return `HTTP/2 200`, deployment is healthy and issue is DNS visibility/resolver path.
+
+## Rollback Approach
+
+Use rollout undo per namespace if a newly deployed ReplicaSet is unhealthy:
+
+```bash
+kubectl -n developer-portal-dev rollout undo deployment/developer-portal
+kubectl -n developer-portal-prod rollout undo deployment/developer-portal
+```
+
+Then verify:
+
+```bash
+kubectl -n developer-portal-dev rollout status deployment/developer-portal
+kubectl -n developer-portal-prod rollout status deployment/developer-portal
+```

--- a/source/runbooks/ingestion-runbook.md
+++ b/source/runbooks/ingestion-runbook.md
@@ -1,0 +1,274 @@
+# Documentation Ingestion Runbook
+
+## Review Dates
+
+- Last reviewed: 2026-04-24
+
+## Purpose
+
+This runbook defines a reusable ingestion process for any repository that
+pulls documentation from external sources and publishes normalized content into
+the portal/site repository.
+
+## Where To Update This Template
+
+Update this file in:
+
+- `docs/runbooks/ingestion-runbook.md`
+
+Add or modify repository-specific values under the section **Repository-Specific Values To Fill**.
+
+## Repository-Specific Values To Fill
+
+Replace placeholders below for your target repository:
+
+- `<ORG>/<REPO>`: GitHub repository slug
+- `<DEFAULT_BRANCH>`: default branch (usually `main`)
+- `<INGEST_WORKFLOW_PATH>`: path to workflow file (for example `.github/workflows/ingest.yml`)
+- `<INGEST_SCRIPT_PATH>`: path to ingestion script (for example `scripts/ingest.mjs`)
+- `<SOURCES_CONFIG_PATH>`: source configuration file (for example `sources.json`)
+- `<CONTENT_OUTPUT_DIR>`: output folder (for example `content/docs`)
+- `<PUBLIC_ASSET_DIR>`: public assets folder (for example `public/docs`)
+- `<NODE_VERSION_VAR>`: Actions variable used by workflow (for example `NODE_VERSION`)
+- `<DISPATCH_EVENT_TYPE>`: repository dispatch type (for example `docs-update`)
+- `<SOURCE_INPUT_NAME>`: manual workflow input name (for example `source`)
+
+Absolute links pattern:
+
+- Repository: `https://github.com/<ORG>/<REPO>`
+- Workflow: `https://github.com/<ORG>/<REPO>/blob/<DEFAULT_BRANCH>/<INGEST_WORKFLOW_PATH>`
+- Script: `https://github.com/<ORG>/<REPO>/blob/<DEFAULT_BRANCH>/<INGEST_SCRIPT_PATH>`
+- Sources config: `https://github.com/<ORG>/<REPO>/blob/<DEFAULT_BRANCH>/<SOURCES_CONFIG_PATH>`
+- Output directory: `https://github.com/<ORG>/<REPO>/tree/<DEFAULT_BRANCH>/<CONTENT_OUTPUT_DIR>`
+
+## Canonical Links
+
+- Repository: `https://github.com/<ORG>/<REPO>`
+- Ingestion workflow: `https://github.com/<ORG>/<REPO>/blob/<DEFAULT_BRANCH>/<INGEST_WORKFLOW_PATH>`
+- Ingestion script: `https://github.com/<ORG>/<REPO>/blob/<DEFAULT_BRANCH>/<INGEST_SCRIPT_PATH>`
+- Sources config: `https://github.com/<ORG>/<REPO>/blob/<DEFAULT_BRANCH>/<SOURCES_CONFIG_PATH>`
+- Output directory: `https://github.com/<ORG>/<REPO>/tree/<DEFAULT_BRANCH>/<CONTENT_OUTPUT_DIR>`
+
+## What Ingestion Should Do
+
+1. Read enabled source definitions from source config.
+2. Clone/pull source repositories into a cache directory.
+3. Convert source docs into normalized markdown/content format.
+4. Write converted docs to `<CONTENT_OUTPUT_DIR>/<source-id>`.
+5. Copy referenced assets to both content and public asset directories.
+6. Write metadata file per source (for example `_meta.json`).
+
+## Source Configuration Contract
+
+Define each source under a list (for example `sources[]`) with fields like:
+
+- `id`: output folder name
+- `repo`: source repo slug (`owner/repo`)
+- `branch`: source branch
+- `docsPath`: docs root path in source repo
+- `format`: converter type (`tech-docs-template`, `markdown`, etc.)
+- `enabled`: include/exclude source
+- `owner_slack` or equivalent owner metadata (optional)
+
+## How To Add A New Source
+
+1. Add a new object under `sources[]` in `<SOURCES_CONFIG_PATH>` with at least:
+
+- `id` (kebab-case, unique)
+- `name`
+- `repo` (`owner/repo`)
+- `branch`
+- `docsPath`
+- `format` (`tech-docs-template` or `markdown`)
+- `enabled` (`true`)
+
+1. Validate source path and format assumptions in the source repo:
+
+- `docsPath` exists on the target branch
+- files under `docsPath` match expected format (`.md`, `.mdx`, or `.html.md.erb` for tech-docs-template)
+
+1. Run a dry run for the new source only:
+
+```bash
+node <INGEST_SCRIPT_PATH> <new-source-id> --dry-run
+```
+
+1. Run a real ingestion for the new source only:
+
+```bash
+node <INGEST_SCRIPT_PATH> <new-source-id>
+```
+
+1. Validate generated output:
+
+- `<CONTENT_OUTPUT_DIR>/<new-source-id>/` exists
+- metadata file exists (for example `_meta.json`)
+- referenced assets are copied as expected
+
+1. Run build validation:
+
+```bash
+npm run build
+```
+
+1. Commit the source config and generated content changes in one PR.
+
+1. Optionally trigger workflow dispatch with `<SOURCE_INPUT_NAME>=<new-source-id>` to validate CI ingestion path.
+
+## Running Ingestion
+
+### Local
+
+```bash
+# Ingest all enabled sources
+node <INGEST_SCRIPT_PATH>
+
+# Ingest a single source
+node <INGEST_SCRIPT_PATH> <source-id>
+
+# Dry run
+node <INGEST_SCRIPT_PATH> --dry-run
+```
+
+### Package Scripts (Optional)
+
+```bash
+npm run ingest
+npm run ingest:dry-run
+npm run ingest:build
+```
+
+## GitHub Actions Trigger Model
+
+Recommended trigger modes:
+
+1. `workflow_dispatch` for manual runs
+2. `schedule` for periodic sync
+3. `repository_dispatch` for source-driven updates
+
+Manual run URL pattern:
+
+`https://github.com/<ORG>/<REPO>/actions/workflows/<INGEST_WORKFLOW_FILE_NAME>`
+
+### Manual Input
+
+Optional input example:
+
+- `<SOURCE_INPUT_NAME>`: source ID (empty means all)
+
+### Repository Dispatch Payload
+
+If workflow expects `client_payload.source_id`:
+
+```json
+{
+  "event_type": "<DISPATCH_EVENT_TYPE>",
+  "client_payload": {
+    "source_id": "<source-id>"
+  }
+}
+```
+
+## Workflow Runtime Requirements
+
+- Node version variable configured (for example `vars.<NODE_VERSION_VAR>`)
+- Workflow permissions to commit content changes (`contents: write`) when auto-commit is enabled
+- Network access from runner to source repositories
+
+## Commit Strategy
+
+Typical post-ingestion behavior:
+
+1. `git add -A`
+2. Exit success if no changes
+3. Commit and push if changes exist
+
+Suggested commit message:
+
+- `chore(ingest): refresh external documentation`
+
+## Validation Checklist
+
+After each ingestion run:
+
+1. Confirm Actions run success.
+1. Verify changed files under `<CONTENT_OUTPUT_DIR>` and `<PUBLIC_ASSET_DIR>`.
+1. Verify metadata file exists for each ingested source.
+1. Run build locally:
+
+```bash
+npm run build
+```
+
+1. Spot-check representative pages for each source.
+
+## Troubleshooting Guide
+
+### No matching sources
+
+Cause:
+
+- Invalid source ID or all sources disabled.
+
+Resolution:
+
+- Validate source ID exists in config.
+- Ensure target source has `enabled: true`.
+
+### Docs path not found
+
+Cause:
+
+- Source docs path changed in upstream repo.
+
+Resolution:
+
+- Update `docsPath` in source config.
+- Re-run ingestion for the affected source.
+
+### Clone/pull failures
+
+Cause:
+
+- Invalid repo/branch or temporary network failure.
+
+Resolution:
+
+- Validate `repo` and `branch` values.
+- Retry workflow run.
+
+### Build fails after ingestion
+
+Cause:
+
+- Converted markdown/content incompatible with local renderer/build.
+
+Resolution:
+
+- Run build locally and inspect failure path.
+- Update conversion logic in ingestion script.
+
+## Useful Operational Commands
+
+```bash
+# Show staged/unstaged ingestion output
+git status --short <CONTENT_OUTPUT_DIR> <PUBLIC_ASSET_DIR>
+
+
+# List source output directories
+ls -1 <CONTENT_OUTPUT_DIR>
+
+# Check metadata files
+find <CONTENT_OUTPUT_DIR> -name "_meta.json"
+
+# Check unresolved ERB markers after conversion
+rg "<%|%>" <CONTENT_OUTPUT_DIR>
+```
+
+## Rollback
+
+If ingestion introduces bad content:
+
+1. Revert ingestion commit(s).
+1. Re-run build checks.
+1. Re-run ingestion only for corrected source after config/script fix.


### PR DESCRIPTION
## What this does
Imports documentation from `ministry-of-justice-developer-portal` as part of a cross-repo move.

| Source | Destination |
|--------|-------------|
| `docs/runbooks/` | `source/runbooks/` |
| `docs/templates/` | `source/documentation/portal content management/` |

## Related
The corresponding removal PR is in [`ministryofjustice/ministry-of-justice-developer-portal`](https://github.com/ministryofjustice/ministry-of-justice-developer-portal/pull/311).