### PR TITLE
Document GitHub dormant user process

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -13,6 +13,7 @@ Technical Documentation used and maintained by the Developer Experience Team.
 
 ## Runbooks
 - [GitHub App Setup Guide](runbooks/github-app-setup.html)
+- [How to Remove a Dormant GitHub User](runbooks/how-to-remove-a-dormant-github-user.html)
 - [Creating a GitHub Personal Access Token (PAT)](runbooks/creating-github-pat.html)
 - [SSO Architecture Runbook](runbooks/sso-architecture.html)
 - [Testing on Developer Portal](runbooks/testing-developer-portal.html)

--- a/source/runbooks/how-to-remove-a-dormant-github-user.erb
+++ b/source/runbooks/how-to-remove-a-dormant-github-user.erb
@@ -1,0 +1,85 @@
+---
+owner_slack: "#developer-experience-team"
+title: How to Remove a Dormant GitHub User
+last_reviewed_on: 2026-06-23
+review_in: 6 months
+---
+
+# How to Remove a Dormant GitHub User
+
+## Purpose
+
+This document provides instructions for identifying and removing dormant GitHub users within the Ministry of Justice GitHub Enterprise. By following this runbook, the Developer Experience team can optimise the use of GitHub licenses, reduce unnecessary costs, and maintain security by ensuring only active users can access enterprise resources.
+
+## Audience
+
+This runbook is primarily for:
+
+* **Developer Experience (DevX) engineers**: to proactively manage dormant GitHub accounts.
+
+## What is a Dormant GitHub User?
+
+According to GitHub, A dormant GitHub user is an account that has not performed any activity within the last 30 days. The [GitHub documentation](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/managing-dormant-users) provides a detailed list of activities that define user activity.
+
+One of the challenges we face is that many services in the Digital space use GitHub as an identity provider to access their systems. Cloud Platform, Analytical Platform, and Modernisation Platform use Auth0 as an authentication mechanism to access various systems. 
+
+As a result, there may be users who depend on access to our GitHub enterprise who would be flagged as dormant  when reviewing GitHub's dormant user report alone.
+
+For reference, activities that count towards user activity include:
+
+- **GitHub**: Creating repositories, pushing to repositories, creating or commenting on issues and pull requests, and various other actions within GitHub.
+
+- **Auth0**: Authenticating to access enterprise resources via SAML SSO, i.e. Cloud Platform, AWS, or the Analytical Platform's Control Panel.
+
+Previously, Auth0 logs were stored and cross-referenced with the GitHub dormant user report to get a more accurate gauge of user activity. This made for an overall complex process and is no longer in place. 
+
+The MoJ is starting to reduce it's dependency on GH as an IdP having adopted EntraID in recent years as another auth mechanism for our services which should in time draw down our use of GitHub as an IdP.
+
+At present we do not have the capacity to cross reference the GH dormant user report with Auth0 logs but in future we may look to re-visit the whole process to make it more sophisticated.
+
+## Why Remove a Dormant GitHub User?
+
+Dormant users can incur unnecessary costs if they hold licenses that could otherwise be allocated to active team members or new users. Additionally, managing dormant users helps maintain security and compliance by reducing the number of potentially inactive accounts that could pose a security risk if compromised.
+
+## What's Required to Remove a Dormant GitHub User?
+
+To remove a dormant GitHub user, you will need:
+
+1. **Access to GitHub Enterprise:** Only enterprise owners or users with sufficient administrative privileges can generate the dormant user report in GitHub.
+1. **Access to Slack:** Notifications of low GitHub license count will be sent to the specified Slack channel [`#developer-experience-alerts`](https://moj.enterprise.slack.com/archives/C0B0RJWMQ01).
+
+## Identify Dormant GitHub Users
+
+At present, removing a dormant GitHub user is a manual process. Follow these steps:
+
+### 1. Download the Dormant Users report from GitHub
+
+First, you need to generate and download the dormant user report from GitHub Enterprise (You need to be a GitHub Enterprise Owner to do this). Follow these steps:
+
+- Navigate to the [GitHub MoJ Enterprise](https://github.com/enterprises/ministry-of-justice-uk).
+- In the sidebar, click **Compliance**.
+- Scroll down to **Reports** and next to **Dormant Users**, click **New report** if a recent report is not already available.
+- Once the report is generated, click **Download** next to the latest dormant users report.
+
+### 2. Identify inactive users to remove 
+
+- Review the dormant user .csv file downloaded from GitHub to identify inactive users 
+
+ > Be aware of "Bot" accounts e.g. `slack-moj` which often show up in the report but should **NOT** be removed as they are likely supporting some form of automation
+
+ > It's best to remove accounts which more obviously belong to an individual i.e. contains a real name
+
+ > It's worth a quick check against each users' profile on GitHub at github.com/<`username`> to verify their inactivity
+
+- Make a note of the usernames you are removing
+
+
+### 3. Remove inactive users from the organisation
+
+- Navigate to the relevant GitHub [organisation](https://github.com/enterprises/ministry-of-justice-uk/organizations) the user is a member of e.g. [ministryofjustice](https://github.com/ministryofjustice) 
+- Select **People**
+- Enter the username of the identified dormant user in the search field
+- Click the checkbox next to the user and select **1 member selected** 
+- Finally select **Remove from organization**
+
+

--- a/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
+++ b/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
@@ -79,7 +79,8 @@ First, you need to generate and download the dormant user report from GitHub Ent
 - Navigate to the relevant GitHub [organisation](https://github.com/enterprises/ministry-of-justice-uk/organizations) the user is a member of e.g. [ministryofjustice](https://github.com/ministryofjustice) 
 - Select **People**
 - Enter the username of the identified dormant user in the search field
-- Click the checkbox next to the user and select **1 member selected** 
+- Click the checkbox next to the user and then click **1 member selected** 
 - Finally select **Remove from organization**
+- If the user is a member of multiple organizations then repeat the previous steps for each
 
 

--- a/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
+++ b/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
@@ -1,7 +1,7 @@
 ---
 owner_slack: "#developer-experience-alerts"
 title: How to Remove a Dormant GitHub User
-last_reviewed_on: 2026-06-23
+last_reviewed_on: 2026-06-26
 review_in: 6 months
 ---
 
@@ -19,17 +19,7 @@ This runbook is primarily for:
 
 ## What is a Dormant GitHub User?
 
-According to GitHub, a dormant GitHub user is an account that has not performed any activity within the last 30 days. The [GitHub documentation](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/managing-dormant-users) provides a detailed list of activities that define user activity.
-
-One challenge is that many MoJ Digital services, including Cloud Platform, Analytical Platform, and Modernisation Platform, still rely on GitHub SSO via Auth0 to access downstream systems.
-
-This means users can still be actively accessing services through Auth0 even when GitHub shows no recent activity, so the GitHub dormant user report alone could produce false positives.
-
-Previously, we reduced this risk by cross-referencing Auth0 logs with the GitHub dormant user report to build a more accurate picture of activity. That process is no longer in place.
-
-At present, we do not have the capacity to cross-reference these data sources, so this manual process is based on the GitHub dormant user report only.
-
-MoJ is reducing its dependency on GitHub-based SSO and has adopted Entra ID as an additional authentication method. Over time, this should reduce reliance on GitHub as the upstream identity source.
+According to GitHub, a dormant GitHub user is an account that has not performed any activity within the last 30 days. The [GitHub documentation](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/managing-dormant-users) provides a detailed list of activities that define user activity. There are some limitations to this definition, which are outlined in [GitHub SSO via Auth0](#github-sso-via-auth0).
 
 ## Why Remove a Dormant GitHub User?
 
@@ -63,17 +53,38 @@ First, generate and download the dormant user report from GitHub Enterprise. You
 
 > Prioritise removing accounts that clearly belong to an individual, for example accounts containing a real name.
 
-> Do a quick sense check against each user's GitHub profile at `https://github.com/<username>` to verify inactivity.
+> Do a quick sense check of each user's GitHub profile at `https://github.com/<username>`, but do not treat this as confirmation of inactivity.
 
-- Make a note of the usernames you are removing
+- Make a note of the usernames you are removing.
 
 ### 3. Remove inactive users from the organisation
 
 - Navigate to the relevant GitHub [organisation](https://github.com/enterprises/ministry-of-justice-uk/organizations) the user is a member of, for example [ministryofjustice](https://github.com/ministryofjustice).
-- Select **People**
-- Enter the username of the identified dormant user in the search field
-- Click the checkbox next to the user, then click **1 member selected**
-- Select **Remove from organization**
+- Select **People**.
+- Enter the username of the identified dormant user in the search field.
+- Click the checkbox next to the user, then click **1 member selected**.
+- Select **Remove from organization**.
 - If the user is a member of multiple organisations, repeat these steps for each organisation.
+
+## Known Issues and Limitations
+
+### User removed in error
+
+If a user is removed from the GitHub organisation in error, they can rejoin within [three months](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-membership-in-your-organization/reinstating-a-former-member-of-your-organization#about-member-reinstatement) and retain their previous permissions. If the user has a `@justice.gov.uk` email address, they can rejoin via SSO using one of the following links:
+
+- [Ministry of Justice](https://github.com/orgs/ministryofjustice/sso)
+- [MoJ Analytical Services Organisation](https://github.com/orgs/moj-analytical-services/sso)
+
+### GitHub SSO via Auth0
+
+Many MoJ Digital services, including Cloud Platform, Analytical Platform, and Modernisation Platform, still rely on GitHub SSO via Auth0 to access downstream systems.
+
+This means users can still be actively accessing services through Auth0 even when GitHub shows no recent activity, so the GitHub dormant user report alone could produce false positives.
+
+Previously, we reduced this risk by cross-referencing Auth0 logs with the GitHub dormant user report to build a more accurate picture of activity. That process is no longer in place.
+
+At present, we do not have the capacity to cross-reference these data sources, so this manual process is based on the GitHub dormant user report only.
+
+MoJ is reducing its dependency on GitHub-based SSO and has adopted Entra ID as an additional authentication method. Over time, this should reduce reliance on GitHub as the upstream identity source.
 
 

--- a/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
+++ b/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
@@ -21,15 +21,15 @@ This runbook is primarily for:
 
 According to GitHub, a dormant GitHub user is an account that has not performed any activity within the last 30 days. The [GitHub documentation](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/managing-dormant-users) provides a detailed list of activities that define user activity.
 
-One challenge is that many of MoJ's Digital services e.g. Cloud Platform, Analytical Platform, and Modernisation Platform use GitHub as an identity provider (IdP) to access their systems via Auth0 as an authentication mechanism.
+One challenge is that many MoJ Digital services, including Cloud Platform, Analytical Platform, and Modernisation Platform, still rely on GitHub SSO via Auth0 to access downstream systems.
 
-As a result, some users who still depend on access to our GitHub enterprise can be flagged as dormant when reviewing GitHub's dormant user report alone.
+This means users can still be actively accessing services through Auth0 even when GitHub shows no recent activity, so the GitHub dormant user report alone could produce false positives.
 
-Previously, Auth0 logs were stored and cross-referenced with the GitHub dormant user report to get a more accurate picture of user activity. This was a complex process and is no longer in place.
+Previously, we reduced this risk by cross-referencing Auth0 logs with the GitHub dormant user report to build a more accurate picture of activity. That process is no longer in place.
 
-MoJ is reducing its dependency on GitHub as an IdP and has adopted Entra ID in recent years as another authentication mechanism for our services. Over time, this should reduce our use of GitHub as an IdP.
+At present, we do not have the capacity to cross-reference these data sources, so this manual process is based on the GitHub dormant user report only.
 
-At present, we do not have the capacity to cross-reference the GitHub dormant user report with Auth0 logs. Moving forward, we plan to revisit this process to make it more sophisticated and automated.
+MoJ is reducing its dependency on GitHub-based SSO and has adopted Entra ID as an additional authentication method. Over time, this should reduce reliance on GitHub as the upstream identity source.
 
 ## Why Remove a Dormant GitHub User?
 

--- a/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
+++ b/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
@@ -40,7 +40,7 @@ Dormant users can incur unnecessary costs if they hold licences that could other
 To remove a dormant GitHub user, you will need:
 
 1. **Access to GitHub Enterprise:** Only enterprise owners or users with sufficient administrative privileges can generate the dormant user report in GitHub.
-1. **Access to a GitHub organisation:** Only organisation owners can remove users from an organisation.
+2. **Access to a GitHub organisation:** Only organisation owners can remove users from an organisation.
 
 ## Identify Dormant GitHub Users
 

--- a/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
+++ b/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
@@ -25,17 +25,11 @@ One of the challenges we face is that many services in the Digital space use Git
 
 As a result, there may be users who depend on access to our GitHub enterprise who would be flagged as dormant  when reviewing GitHub's dormant user report alone.
 
-For reference, activities that count towards user activity include:
-
-- **GitHub**: Creating repositories, pushing to repositories, creating or commenting on issues and pull requests, and various other actions within GitHub.
-
-- **Auth0**: Authenticating to access enterprise resources via SAML SSO, i.e. Cloud Platform, AWS, or the Analytical Platform's Control Panel.
-
 Previously, Auth0 logs were stored and cross-referenced with the GitHub dormant user report to get a more accurate gauge of user activity. This made for an overall complex process and is no longer in place. 
 
 The MoJ is starting to reduce it's dependency on GH as an IdP having adopted EntraID in recent years as another auth mechanism for our services which should in time draw down our use of GitHub as an IdP.
 
-At present we do not have the capacity to cross reference the GH dormant user report with Auth0 logs but in future we may look to re-visit the whole process to make it more sophisticated.
+At present we do not have the capacity to cross reference the GH dormant user report with Auth0 logs but moving forward we plan to re-visit the whole process to make it more sophisticated and as automated as possible.
 
 ## Why Remove a Dormant GitHub User?
 
@@ -46,7 +40,7 @@ Dormant users can incur unnecessary costs if they hold licenses that could other
 To remove a dormant GitHub user, you will need:
 
 1. **Access to GitHub Enterprise:** Only enterprise owners or users with sufficient administrative privileges can generate the dormant user report in GitHub.
-1. **Access to Slack:** Notifications of low GitHub license count will be sent to the specified Slack channel [`#developer-experience-alerts`](https://moj.enterprise.slack.com/archives/C0B0RJWMQ01).
+1. **Access to GitHub Organisation:** Only organisation owners can remove users from an organisation
 
 ## Identify Dormant GitHub Users
 
@@ -65,11 +59,11 @@ First, you need to generate and download the dormant user report from GitHub Ent
 
 - Review the dormant user .csv file downloaded from GitHub to identify inactive users 
 
- > Be aware of "Bot" accounts e.g. `slack-moj` which often show up in the report but should **NOT** be removed as they are likely supporting some form of automation
+ > Be aware of "Bot" accounts e.g. `slack-moj` which often show up in the report but should **NOT** be removed as they are likely supporting some form of automation (we need to investigate these further when making improvements)
 
  > It's best to remove accounts which more obviously belong to an individual i.e. contains a real name
 
- > It's worth a quick check against each users' profile on GitHub at github.com/<`username`> to verify their inactivity
+ > It's worth a quick sense check against each users' profile on GitHub at github.com/<`username`> to verify their inactivity
 
 - Make a note of the usernames you are removing
 

--- a/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
+++ b/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 ## Purpose
 
-This document provides instructions for identifying and removing dormant GitHub users within the Ministry of Justice GitHub Enterprise. By following this runbook, the Developer Experience team can optimise the use of GitHub licenses, reduce unnecessary costs, and maintain security by ensuring only active users can access enterprise resources.
+This document provides instructions for identifying and removing dormant GitHub users within the Ministry of Justice GitHub Enterprise. By following this runbook, the Developer Experience team can optimise the use of GitHub licences, reduce unnecessary costs, and maintain security by ensuring only active users can access enterprise resources.
 
 ## Audience
 
@@ -19,28 +19,28 @@ This runbook is primarily for:
 
 ## What is a Dormant GitHub User?
 
-According to GitHub, A dormant GitHub user is an account that has not performed any activity within the last 30 days. The [GitHub documentation](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/managing-dormant-users) provides a detailed list of activities that define user activity.
+According to GitHub, a dormant GitHub user is an account that has not performed any activity within the last 30 days. The [GitHub documentation](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/managing-dormant-users) provides a detailed list of activities that define user activity.
 
-One of the challenges we face is that many services in the Digital space use GitHub as an identity provider to access their systems. Cloud Platform, Analytical Platform, and Modernisation Platform use Auth0 as an authentication mechanism to access various systems. 
+One challenge is that many of MoJ's Digital services e.g. Cloud Platform, Analytical Platform, and Modernisation Platform use GitHub as an identity provider (IdP) to access their systems via Auth0 as an authentication mechanism.
 
-As a result, there may be users who depend on access to our GitHub enterprise who would be flagged as dormant  when reviewing GitHub's dormant user report alone.
+As a result, some users who still depend on access to our GitHub enterprise can be flagged as dormant when reviewing GitHub's dormant user report alone.
 
-Previously, Auth0 logs were stored and cross-referenced with the GitHub dormant user report to get a more accurate gauge of user activity. This made for an overall complex process and is no longer in place. 
+Previously, Auth0 logs were stored and cross-referenced with the GitHub dormant user report to get a more accurate picture of user activity. This was a complex process and is no longer in place.
 
-The MoJ is starting to reduce it's dependency on GH as an IdP having adopted EntraID in recent years as another auth mechanism for our services which should in time draw down our use of GitHub as an IdP.
+MoJ is reducing its dependency on GitHub as an IdP and has adopted Entra ID in recent years as another authentication mechanism for our services. Over time, this should reduce our use of GitHub as an IdP.
 
-At present we do not have the capacity to cross reference the GH dormant user report with Auth0 logs but moving forward we plan to re-visit the whole process to make it more sophisticated and as automated as possible.
+At present, we do not have the capacity to cross-reference the GitHub dormant user report with Auth0 logs. Moving forward, we plan to revisit this process to make it more sophisticated and automated.
 
 ## Why Remove a Dormant GitHub User?
 
-Dormant users can incur unnecessary costs if they hold licenses that could otherwise be allocated to active team members or new users. Additionally, managing dormant users helps maintain security and compliance by reducing the number of potentially inactive accounts that could pose a security risk if compromised.
+Dormant users can incur unnecessary costs if they hold licences that could otherwise be allocated to active team members or new users. Additionally, managing dormant users helps maintain security and compliance by reducing the number of potentially inactive accounts that could pose a security risk if compromised.
 
 ## What's Required to Remove a Dormant GitHub User?
 
 To remove a dormant GitHub user, you will need:
 
 1. **Access to GitHub Enterprise:** Only enterprise owners or users with sufficient administrative privileges can generate the dormant user report in GitHub.
-1. **Access to GitHub Organisation:** Only organisation owners can remove users from an organisation
+1. **Access to a GitHub organisation:** Only organisation owners can remove users from an organisation.
 
 ## Identify Dormant GitHub Users
 
@@ -48,33 +48,32 @@ At present, removing a dormant GitHub user is a manual process. Follow these ste
 
 ### 1. Download the Dormant Users report from GitHub
 
-First, you need to generate and download the dormant user report from GitHub Enterprise (You need to be a GitHub Enterprise Owner to do this). Follow these steps:
+First, generate and download the dormant user report from GitHub Enterprise. You need to be a GitHub Enterprise owner to do this. Follow these steps:
 
 - Navigate to the [GitHub MoJ Enterprise](https://github.com/enterprises/ministry-of-justice-uk).
 - In the sidebar, click **Compliance**.
 - Scroll down to **Reports** and next to **Dormant Users**, click **New report** if a recent report is not already available.
 - Once the report is generated, click **Download** next to the latest dormant users report.
 
-### 2. Identify inactive users to remove 
+### 2. Identify inactive users to remove
 
-- Review the dormant user .csv file downloaded from GitHub to identify inactive users 
+- Review the dormant user CSV file downloaded from GitHub to identify inactive users.
 
- > Be aware of "Bot" accounts e.g. `slack-moj` which often show up in the report but should **NOT** be removed as they are likely supporting some form of automation (we need to investigate these further when making improvements)
+> Be aware of bot accounts, for example `slack-moj`. These often appear in the report but should **not** be removed, as they are likely supporting some form of automation.
 
- > It's best to remove accounts which more obviously belong to an individual i.e. contains a real name
+> Prioritise removing accounts that clearly belong to an individual, for example accounts containing a real name.
 
- > It's worth a quick sense check against each users' profile on GitHub at github.com/<`username`> to verify their inactivity
+> Do a quick sense check against each user's GitHub profile at `https://github.com/<username>` to verify inactivity.
 
 - Make a note of the usernames you are removing
 
-
 ### 3. Remove inactive users from the organisation
 
-- Navigate to the relevant GitHub [organisation](https://github.com/enterprises/ministry-of-justice-uk/organizations) the user is a member of e.g. [ministryofjustice](https://github.com/ministryofjustice) 
+- Navigate to the relevant GitHub [organisation](https://github.com/enterprises/ministry-of-justice-uk/organizations) the user is a member of, for example [ministryofjustice](https://github.com/ministryofjustice).
 - Select **People**
 - Enter the username of the identified dormant user in the search field
-- Click the checkbox next to the user and then click **1 member selected** 
-- Finally select **Remove from organization**
-- If the user is a member of multiple organizations then repeat the previous steps for each
+- Click the checkbox next to the user, then click **1 member selected**
+- Select **Remove from organization**
+- If the user is a member of multiple organisations, repeat these steps for each organisation.
 
 

--- a/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
+++ b/source/runbooks/how-to-remove-a-dormant-github-user.html.md.erb
@@ -1,5 +1,5 @@
 ---
-owner_slack: "#developer-experience-team"
+owner_slack: "#developer-experience-alerts"
 title: How to Remove a Dormant GitHub User
 last_reviewed_on: 2026-06-23
 review_in: 6 months


### PR DESCRIPTION
## What?

Closes Issue [#180](https://github.com/ministryofjustice/moj-github-discovery/issues/180)

This PR introduces a new runbook detailing how to remove a dormant GitHub user.

It is based on a legacy guide that can be viewed [here](https://cloud-optimisation-and-accountability.justice.gov.uk/documentation/operations-engineering-legacy/operations-engineering-runbooks/tools/remove-dormant-users.html#how-to-remove-a-dormant-github-user) 

## Changes

- It has been updated to reflect the process of ownership coming into the DevX 
- Documents the current manual process as it stands (there is no longer an automated process for cross-referencing with Auth0 logs for example)

In time I hope we can update this guide as we start to re-introduce some more automation and proactive monitoring of license count.