### PR TITLE
docs(runbook): add github users sync app name

### DIFF
--- a/source/runbooks/github-member-management-workflows-runbook.html.md.erb
+++ b/source/runbooks/github-member-management-workflows-runbook.html.md.erb
@@ -89,6 +89,9 @@ The Python script (`scripts.add_users_all_org_members_github_team`):
 
 The same app credentials are used for both workflows, but the app must be installed in both `ministryofjustice` and `moj-analytical-services` organizations.
 
+Use this enterprise app for `APP_ID` and `APP_PRIVATE_KEY`:
+- MOJ GitHub Users Sync App
+
 **Adding Secrets**:
 1. Go to: Settings → Secrets and variables → Actions → Secrets
 2. Click "New repository secret"


### PR DESCRIPTION
## Summary
This PR updates the GitHub Member Management Workflows runbook to explicitly name the enterprise GitHub App used for authentication secrets.

## What changed
Added the app name under prerequisites for APP_ID and APP_PRIVATE_KEY.

## File changed
github-member-management-workflows-runbook.html.md.erb
