### PR TITLE
✨ Add Ways of Engineering Document

### DIFF
--- a/source/documentation/general-information/ways-of-engineering.html.md.erb
+++ b/source/documentation/general-information/ways-of-engineering.html.md.erb
@@ -1,0 +1,132 @@
+---
+owner_slack: "#developer-experience-alerts"
+title: Our Ways of Engineering
+last_reviewed_on: 2026-07-01
+review_in: 6 months
+---
+
+# Our Ways of Engineering
+
+This foundational document outlines the Developer Experience Teams collective approach to engineering practices, fostering a culture of continuous improvement, innovation, and excellence. It is a compass for our technical journey, guiding us to make informed decisions, embrace best practices, and explore new technologies. This document aims to harmonise our engineering efforts, ensuring efficiency, quality, and sustainability in our projects.
+
+**Statuses:**
+
+- ✅ Accepted
+- 🧪 Experimenting
+- 💡 New idea (waiting to be discussed by the team)
+- ⏸️ Paused (waiting for an experiment to complete)
+
+## Engineering Principles
+
+These principles are intended to guide technical decision-making within the Developer Experience team. They are not absolute rules. Instead, they provide a shared framework for evaluating technologies, architecture, tooling and ways of working. Where trade-offs exist, the principles should be considered together and applied using engineering judgement.
+
+These principles should evolve alongside our team and the products we build. As they are applied to real engineering decisions, we should regularly reflect on whether they continue to represent our values and support good outcomes. Where necessary, they should be refined, expanded or simplified based on our experiences, ensuring they remain practical, relevant and effective rather than becoming static guidance.
+
+### ✅ 1. Build Security In by Design
+
+Security should be considered from the outset of every project rather than being treated as a later activity. We aim to reduce risk by making secure choices the default.
+
+**Heuristics**
+
+- Automate security scanning within CI/CD pipelines.
+- Continuously develop security knowledge across the team.
+- Maintain an active vulnerability management process.
+- Prefer approved third-party tools and integrations where appropriate.
+- Minimise the attack surface by reducing unnecessary tooling.
+
+### ✅ 2. Favour Established Patterns and Proven Practices
+
+Building upon established patterns helps improve consistency, reduces cognitive load and enables engineers to build on existing knowledge rather than reinventing solutions.
+
+**Heuristics**
+
+- Make use of the MoJ Tech Radar when evaluating technologies.
+- Reuse existing MoJ platforms, components and patterns where appropriate.
+- Use established architectural patterns and design artefacts to communicate solutions.
+- Adopt our own products and tooling where they meet our needs.
+
+### ✅ 3. Keep Documentation Clear, Concise and Maintainable
+
+Documentation is a core part of delivering software. It should be easy to find, understand and maintain throughout the lifetime of a system.
+
+**Heuristics**
+
+- Include documentation within the Definition of Done and review process.
+- Assign ownership for documentation and define regular review cadences.
+- Maintain internal runbooks for operational knowledge.
+- Ensure documentation is easy to navigate and search.
+
+### ✅ 4. Enable Rapid Feedback
+
+Fast feedback enables engineers to identify issues early, reduce delivery risk and iterate with confidence.
+
+**Heuristics**
+
+- Provide clear logging and actionable error handling.
+- Support efficient local development environments.
+- Measure and improve feedback loops using meaningful metrics.
+- Adopt DORA metrics where appropriate.
+
+### ✅ 5. Automate Delivery Wherever It Adds Value
+
+Automation should be used to improve consistency, reliability and efficiency, allowing engineers to focus on higher-value work.
+
+**Heuristics**
+
+- Invest in automation that improves reliability, consistency or delivery speed.
+- Continuously improve deployment pipelines.
+
+### ✅ 6. Make Systems Observable from the Start
+
+Observability should be designed into systems from the beginning so that their health, behaviour and performance can be understood throughout their lifecycle.
+
+**Heuristics**
+
+- Design observability into new systems from the outset.
+- Ensure each component exposes appropriate telemetry, logging and monitoring.
+
+## Hosting Services and Infrastructure
+
+### ✅ Use GitHub as the Central Platform for Code and Collaboration
+
+GitHub is our default platform for source control, code review, issue tracking, and CI/CD integration. It provides a consistent workflow for managing code and collaboration across the team.
+
+### ✅ Use GitHub Services for Lightweight Infrastructure Needs
+
+GitHub Actions and GitHub Pages should be used for small-scale infrastructure requirements such as CI/CD workflows, static sites, and documentation.
+
+This reduces operational overhead and avoids introducing additional infrastructure for simple use cases.
+
+- GitHub Pages: static sites, documentation, project portals  
+- GitHub Actions: CI/CD, testing, and automation workflows  
+
+### ✅ Use the Cloud Platform for Production Application Hosting
+
+The Cloud Platform is the default hosting environment for containerised applications and services, providing managed infrastructure and access to AWS capabilities.
+
+New applications should be hosted on the Cloud Platform unless there is a clear technical or operational reason to use an alternative.
+
+## Technology Choices
+
+We use different technologies depending on the type of problem being solved.
+
+### ✅ Languages
+
+- Python: automation and scripting
+- JavaScript: web applications and tooling
+
+### ✅ Application Frameworks
+
+- Next.js: web application framework used for the Developer Portal
+
+### ✅ Engineering Tooling
+
+- Dependabot: automated dependency updates and security maintenance
+
+## Adding/Adjusting Ways of Engineering
+
+To maintain the relevance and effectiveness of our Ways of Engineering, we encourage team members to propose adjustments or additions. Suggestions can be discussed in dedicated Slack channels, Engineering Guild meetings, or directly through Pull Requests. Your contributions are crucial in ensuring our engineering practices remain dynamic, inclusive, and aligned with our goals.
+
+### Experimental Engineering Practices
+
+We’re committed to innovation in our projects and how we work together as an engineering team. Experimenting with new practices allows us to improve and adapt to the changing tech landscape continuously. Participation and feedback from all team members are essential for these experiments to yield valuable insights and guide our evolution.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -12,6 +12,7 @@ review_in: 6 months
 Technical Documentation used and maintained by the Developer Experience Team.
 
 ## Runbooks
+
 - [Add a runbook](runbooks/add-a-runbook.html)
 - [GitHub App Setup Guide](runbooks/github-app-setup.html)
 - [How to Remove a Dormant GitHub User](runbooks/how-to-remove-a-dormant-github-user.html)
@@ -28,16 +29,20 @@ Technical Documentation used and maintained by the Developer Experience Team.
 - [Portal Testing Runbook](runbooks/testing-developer-portal.html)
 
 ## General Information
+
 - [Our Team](documentation/general-information/our-team.html)
 - [Our Ceremonies](documentation/general-information/our-ceremonies.html)
 - [Our Alliance](documentation/general-information/our-alliance.html)
+- [Our Ways of Engineering](documentation/general-information/ways-of-engineering.html)
 
 ## Team Guide
+
 - [Team Tools](documentation/team-guide/team-tools.html)
 - [Useful Scripts](documentation/team-guide/useful-scripts.html)
 - [Dependabot PR Tracking](documentation/team-guide/dependabot-pr-tracking.html)
 
 ## Content Ingestion
+
 - [Content Ingestion Pipeline](documentation/content-ingestion/index.html)
 - [Pipeline Architecture](documentation/content-ingestion/architecture.html)
 - [Adding New Documentation Formats (Parsers)](documentation/content-ingestion/extending-parsers.html)
@@ -56,4 +61,3 @@ Technical Documentation used and maintained by the Developer Experience Team.
 
 [Architecture Decision Records](documentation/adrs/adr-index.html)
 
-[README]: https://github.com/ministryofjustice/developer-experience-documentation


### PR DESCRIPTION
## 👀 Purpose

- ✅ Completing the action of `@Connor Glynn to writeup and publish on DevX Docs` from our first [Technical Foundations Session](https://miro.com/app/board/uXjVGvXO1sc=/?moveToWidget=3458764677063035652&cot=14)
- 🤲 To publicly document our agreed engineering principles, to enable the team to consistently apply the same standard to, and critically analyse, technology choices

## ♻️ What's changed

- ✨ Added a new page named `Our Ways of Engineering`, which contains:
  - Engineering Principles
  - How We Host Services
  - Our general Technology Choices (languages, frameworks, etc.)
- ✨ Added in some of the general technology choices I've seen so far (just to get them documented for now, we can revisit the choices later 😁)
- 🔥 Remove unused text at the bottom of the index file

## 📝 Notes

- NA