### PR TITLE
#170: Centralise and Structure documentation

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Dependency Review
         id: dependency_review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: critical

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -36,13 +36,13 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Lychee
         id: lychee
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429,301,302
           fail: true

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload Built Site Snapshot
         id: upload_built_snapshot
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: built-site-snapshot
           path: out

--- a/source/documentation/general-information/documentation-and-knowledge-management.html.md.erb
+++ b/source/documentation/general-information/documentation-and-knowledge-management.html.md.erb
@@ -1,0 +1,35 @@
+---
+owner_slack: "#developer-experience-alerts"
+title: Documentation and Knowledge Management
+last_reviewed_on: 2026-07-16
+review_in: 6 months
+---
+
+# Documentation and Knowledge Management
+
+The DevX team maintains documentation across several locations depending on its purpose and audience.
+Understanding where to find documentation and how to contribute to it is important for both new joiners and existing team members.
+
+For a full breakdown of what lives where and why, refer to the [Documentation Structure Proposal](https://justiceuk.sharepoint.com/:w:/r/sites/DeveloperExperienceDevX-DevTooling/Shared%20Documents/170_Internal_Documentation_Proposal.docx?d=we05a9c8ac1a3457fbb79460c75018377&csf=1&web=1&e=O8EbBz) developed as part of issue [170](https://github.com/ministryofjustice/moj-github-discovery/issues/170).
+This proposal covers the team's documentation locations, content lifecycle, and versioning conventions.
+
+A quick reference summary is also available below - for day-to-day navigation, this should be your first port of call.
+
+## What Lives Where?
+
+| Documentation Type | SharePoint | DevX-Documentation-Site | Repo READMEs | Engineering Portal / Blueprint |
+| ------------------- | ----------- | ----------------------- | ------------- | ------------------------------- |
+| Meeting Notes | ✅ | ❌ | ❌ | ❌ |
+| Decision Logs | ✅ | ✅ (ADRs) | ❌ | ❌ |
+| Sprint Reviews | ✅ | ❌ | ❌ | ❌ |
+| Audit / Ticket Findings | ✅ (Raw) | ✅ (Refined) | ❌ | ❌ |
+| Tooling Setup and Usage Guides | ❌ | ✅ | ✅ (Quickstart) | ❌ |
+| Runbooks | ❌ | ✅ | ❌ | ❌ |
+| Org-Wide Standards and Guidelines | ❌ | ❌ | ❌ | ✅ |
+| Onboarding Guides | ❌ | ✅ | ❌ | ❌ |
+
+## SharePoint Index
+
+For a full inventory of internal team documentation, including audit findings, POC outputs, and sprint artefacts, refer to the [DevX SharePoint Index](https://justiceuk.sharepoint.com/:w:/r/sites/DeveloperExperienceDevX-DevTooling/Shared%20Documents/DevX_SharePoint_Index.docx?d=w9b5e0253d2c246b2a02f199a341e0628&csf=1&web=1&e=YfIbEJ).
+
+

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -34,6 +34,7 @@ Technical Documentation used and maintained by the Developer Experience Team.
 
 ## General Information
 
+- [Documentation and Knowledge Management](documentation/general-information/documentation-and-knowledge-management.html)
 - [Our Team](documentation/general-information/our-team.html)
 - [Our Ceremonies](documentation/general-information/our-ceremonies.html)
 - [Our Alliance](documentation/general-information/our-alliance.html)


### PR DESCRIPTION
# Overview

Closes [#170](https://github.com/ministryofjustice/moj-github-discovery/issues/170)

# Resolution

- Adds Documentation and Knowledge Management page under **General Information**
- Includes summary table of "what lives where", and links to the sharepoint index doc and documentation proposal developed as part of [#170 ](https://github.com/ministryofjustice/moj-github-discovery/issues/170) and [#171 ](https://github.com/ministryofjustice/moj-github-discovery/issues/171)respectively.

# Misc

- Covers off dependabot upgrades #37 - #40 