### PR TITLE
#44 - Fill Documentation Gaps (SharePoint to developer-experience-documentation)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Introduction :pencil2:
+
+Include a summary of the changes and related feature(s) or issue(s).
+
+## Resolution :heavy_check_mark:
+
+List all changes made to the codebase.
+
+## Miscellaneous :heavy_plus_sign:
+
+List any additional fixes or improvements.
+
+## Screenshot(s) :camera_flash:
+
+<details>
+  <summary>Show/hide</summary>
+
+Add screenshots here.
+
+</details>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,6 +30,10 @@ Technical Documentation used and maintained by the Developer Experience Team.
 - [SSO Architecture Runbook](runbooks/sso-architecture.html)
 - [Portal Testing Runbook](runbooks/testing-developer-portal.html)
 
+## Standards
+
+- [GitHub Actions Cloud Authentication Credential Usage](standards/github-actions-cloud-authentication.html)
+
 ## POC/Discovery/Spike Findings
 - [SBOM POC Discovery Findings Runbook](poc-discovery-spike-findings/runbooks/sbom-poc-discovery-findings-runbook.html)
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -33,6 +33,7 @@ Technical Documentation used and maintained by the Developer Experience Team.
 ## Standards
 
 - [GitHub Actions Cloud Authentication Credential Usage](standards/github-actions-cloud-authentication.html)
+- [GitHub Repository Archival](standards/github-repository-archival.html)
 
 ## POC/Discovery/Spike Findings
 - [SBOM POC Discovery Findings Runbook](poc-discovery-spike-findings/runbooks/sbom-poc-discovery-findings-runbook.html)

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -14,6 +14,7 @@ Technical Documentation used and maintained by the Developer Experience Team.
 ## Runbooks
 
 - [Add a runbook](runbooks/add-a-runbook.html)
+- [Archiving a GitHub Repository Checklist](runbooks/archiving-a-github-repository.html)
 - [GitHub App Setup Guide](runbooks/github-app-setup.html)
 - [How to Remove a Dormant GitHub User](runbooks/how-to-remove-a-dormant-github-user.html)
 - [Creating a GitHub Personal Access Token (PAT)](runbooks/creating-github-pat.html)

--- a/source/runbooks/archiving-a-github-repository.html.md.erb
+++ b/source/runbooks/archiving-a-github-repository.html.md.erb
@@ -1,0 +1,76 @@
+---
+owner_slack: "#developer-experience-team"
+title: Archiving a GitHub Repository Checklist
+last_reviewed_on: 2026-07-17
+review_in: 6 months
+---
+
+# Archiving a GitHub Repository Checklist
+
+This runbook provides a checklist for archiving a GitHub repository. Archiving a repository makes it read-only and prevents any further changes, but it does not delete the repository or its contents.
+
+## 1. Confirm Archiving is Appropriate
+
+Before archiving a repository, ensure that it is no longer actively maintained or needed for development. Consider the following mandatory and supporting signals:
+
+**Mandatory Signals:**
+
+- Verify no deployments or active development are occurring in the repository.
+- Verify in [cloud-platform]() the repository does not have a corresponding environment or namespace.
+- Verify no CI/CD pipelines or workflows are actively running from the repository.
+- Verify that the repository is not a dependency for any other active projects or services.
+
+**Supporting Signals:**
+
+- Check if the repository has not had any commits to the main branch in the last 12 months.
+- Check if the repository has not had any pull requests merged in the last 12 months.
+- Check if the repository has any clear CODEOWNERS or maintainers listed, and if they are still active in the organization.
+- Check if the repository has any open issues or pull requests that have been inactive for a long time.
+- Check if the repository has any documentation or README files that indicate it is still in use or maintained.
+
+## 2. Pre-Archival Checklist
+
+Once confirmed that archiving is appropriate, complete the following pre-archival checklist to minimize disruption and ensure that all necessary information is preserved:
+
+1. Confirm archival eligibility in line with the signals above.
+2. Confirm no downstream dependencies exist that would be affected by archiving the repository.
+3. Ensure CODEOWNERS is defined and up to date, and that all relevant stakeholders are aware of the archiving decision.
+4. Close any open issues or pull requests, or communicate with contributors about the archiving plan.
+5. Update the README or documentation to indicate that the repository is archived and no longer maintained, including any relevant links to alternative resources or active repositories.
+
+## 3. Security and Deactivation Checklist
+
+To ensure the process is carried out securely and that access is appropriately managed, complete the following security and deactivation checklist:
+
+1. Remove all secrets associated with the repository, including GitHub Actions secrets and any other sensitive information.
+2. Revoke any tokens, API keys, or credentials that are associated with the repository to prevent unauthorized access.
+3. Disable GitHub Actions workflows to prevent any automated processes from running after the repository is archived.
+4. Remove any webhooks or integrations that are connected to the repository to prevent external systems from interacting with it.
+5. Decommission any associated services or applications that rely on the repository, ensuring that they are no longer active or accessible.
+
+## 4. Access Control Checklist
+
+To ensure that access to the repository is appropriately managed after archiving, complete the following access control checklist:
+
+1. Set repository visibility to private if it is currently public, to limit access to authorized users only.
+2. Ensure no sensitive data or information is exposed in the repository before archiving, and remove any such data if necessary.
+3. Restrict access to the repository by removing any unnecessary collaborators or teams, and ensure that only authorized personnel have access.
+
+## 5. Apply Archival Settings
+
+Once the above checklists have been completed, apply the archival settings to the repository:
+
+1. Apply the "Archive this repository" setting in the repository settings on GitHub. This will make the repository read-only and prevent any further changes.
+2. Confirm the setting has been implemented and the repository is read-only by attempting to make a change or commit to the repository. You should receive a message indicating that the repository is archived and cannot be modified.
+
+## 6. Post-Archival Checklist
+
+After archiving the repository, complete the following post-archival checklist to ensure that all necessary information is preserved and that stakeholders are informed:
+
+1. Ensure no workflows or automated processes are running from the repository after archiving, and that any scheduled tasks or cron jobs are disabled.
+2. The repository is non-operational and cannot be used for development or deployment, and that any attempts to access or modify the repository are blocked.
+3. The CODEOWNERS file reflects the current ownership and responsibilities for the archived repository, and that any relevant stakeholders are aware of the archiving decision.
+
+## 7. Governance and Compliance Checklist
+
+Post-archival, the repository should be reviewed on a quarterly basis to ensure that it remains compliant with organizational policies and governance standards.

--- a/source/standards/github-actions-cloud-authentication.html.md.erb
+++ b/source/standards/github-actions-cloud-authentication.html.md.erb
@@ -46,24 +46,205 @@ Continued use of long-lived credentials exposes MoJ to credential exfiltration t
 
 ## 2. Distinguishing the Identity Provider from the Credential Mechanism
 
+Both concern authentication (AuthN) — proving which workload is calling the cloud — as distinct from authorisation (AuthZ), which governs what that workload may then do (covered here only by the least-privilege requirements).
+Per Microsoft's identity platform guidance, OIDC is the protocol used for authentication, which is precisely the mechanism this standard mandates. Within AuthN, the identity provider and the credential mechanism are independent decisions, and teams MUST be able to state the credential mechanism, not only the identity provider:
+
+**Identity provider (who the workload is):**
+
+For nearly all MoJ teams this is Entra ID (Azure AD), the org-wide SSO. This is true regardless of how any individual workflow authenticates, so “we use Entra ID” does not describe compliance.
+
+**Credential mechanism (how the workflow proves it at runtime):**
+
+This is what this standard governs. It MUST be one of: a short-lived OIDC federated token (compliant), or a stored long-lived secret (non-compliant, exception required).
+
+An Entra ID app registration can use either mechanism: a registration authenticating via a federated credential is compliant OIDC, while the same registration authenticating via a client secret is a long-lived credential. 
+“We use Entra ID” and “this is long-lived” are frequently both true at once. 
+
+When establishing a workflow's posture, teams MUST ask questions that name the mechanism directly:
+
+- **AWS:**
+  - Does the workflow assume an IAM role via aws-actions/configure-aws-credentials with role-to-assume and `id-token: write`?
+  - Does the workflow use a stored AWS access key and secret in GitHub secrets?
+- **Azure:**
+    - Does the Entra app registration use a federated credential (no stored secret), or a client secret / certificate
+    - Does the workflow use azure/login with `id-token: write`?
+- Is the flagged workflow file actively used in the repository, or is it a dormant workflow that has been left in the repo?
+- Are there any long-lived secrets stored in the repository, even if it's using OIDC for some workflows? (e.g., a stored AWS access key or Azure client secret)
+
 ## 3. Workflows Using `id-token: write` When Using OIDC
+
+A workflow is performing OIDC if and only if the job sets permissions: `id-token: write` and uses a cloud-side role or identity assumption (`aws-actions/configure-aws-credentials` with `role-to-assume`, `azure/login` with a federated client-id, or `google-github-actions/auth`).
+
+A workflow without `id-token: write` MUST NOT be treated as OIDC, because the runner cannot mint an OIDC token without it.
+Where such a workflow also references `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, `AZURE_CLIENT_SECRET`, or `GCP_SA_KEY`, it is long-lived. 
+This is the authoritative signal and is reported by the central audit tooling (moj-github-discovery) as the `has_id_token_write` field.
 
 ## 4. Exceptions for Long-lived Credentials
 
+Before logging an exception, teams MUST first confirm the workflow is still in use; obsolete workflow files MUST be deleted rather than migrated or excepted. Long-lived credentials MAY be retained only where one of the following applies: 
+
+1. The target service does not support OIDC federation. 
+2. OIDC is technically possible but not yet enabled by the platform team (temporary only; remediation MUST be tracked). 
+3. There is a lack of project support, ownership, or capacity to migrate. This is an organisational blocker and the exception MUST name the blocker, an accountable owner, and a target review date. 
+4. The credential is for a non-cloud-provider service, in which case it is out of scope for this standard but MUST follow general MoJ secret management guidance. 
+
+Where an exception applies, the team MUST:
+
+- Record it in the team risk log with a justification and review date. 
+- Restrict the credential to least-privilege permissions. 
+- Use the naming convention below so audit tooling can discover it. 
+- Rotate it on a defined schedule of no longer than 90 days unless the platform team specifies otherwise. 
+  - An unrotated long-lived credential is a finding in its own right and MUST NOT be treated as a steady state. 
+- Review the exception at least annually. 
+
 ## 5. Identifying High-Blast-Radius Repositories
+
+Where a single repository controls a disproportionate share of an estate — for example a DNS repository managing approximately 99.99% of MoJ DNS — it MUST be classified as a Risk Asset and its migration prioritised, even where its keys are least-privilege scoped. 
+Scope reduces the permissions blast radius but not the operational blast radius of the systems the repository governs. 
+For such repositories, “never rotated” combined with “no clear migration owner” MUST be escalated to team leadership rather than left in the risk log. 
 
 ## 6. Credential and Variable Naming Convention
 
+A standardised naming convention is required so that credential usage is discoverable by moj-github-discovery and workflows are readable across teams. Non-standard names defeat automated scanning and MUST NOT be used. 
+
+OIDC role ARNs and regions are configuration, not secrets, and MUST be stored as GitHub Actions variables: 
+
+- **AWS:**
+  - `AWS_ROLE_TO_ASSUME`
+  - `AWS_REGION`
+- **Azure:**
+  - `AZURE_CLIENT_ID`
+  - `AZURE_TENANT_ID`
+  - `AZURE_SUBSCRIPTION_ID`
+- **GCP:**
+  - `GCP_WORKLOAD_IDENTITY_PROVIDER`
+  - `GCP_SERVICE_ACCOUNT`
+
+Where long-lived credentials are retained under an exception, they MUST be stored as GitHub Actions secrets using these canonical names: 
+
+- **AWS:**
+  - `AWS_ACCESS_KEY_ID`
+  - `AWS_SECRET_ACCESS_KEY`
+  - `AWS_SESSION_TOKEN` (optional)
+- **Azure:**
+  - `AZURE_CREDENTIALS`
+  - `AZURE_CLIENT_SECRET`
+- **GCP:**
+  - `GCP_SA_KEY`
+
+Environment-specific values MUST be prefixed in upper case, for example `PROD_AWS_ROLE_TO_ASSUME` or `DEV_AWS_ACCESS_KEY_ID`.
+
+The following MUST NOT be used: 
+
+- Custom or abbreviated names (`MY_AWS_KEY`, `ACCESS_TOKEN`, `CLOUD_KEY`, `K`, `SECRET1`)
+- Personal or team-prefixed names (`JOHN_AWS_KEY`, `TEAM_X_AWS_SECRET`)
+- Credentials stored as plaintext in workflow files, repository variables, or .env files, which MUST be treated as a security incident rather than a compliance deviation. 
+
 ## 7. Flagged Repositories and the Verification Process
+
+A long_lived_credentials classification from moj-github-discovery is a candidate for review, not a confirmed finding.
+The scan cannot determine whether a flagged file is still in use, or whether a stored secret is live or dormant.
+A flagged workflow MUST be resolved into one of three states: 
+
+1. Genuine long-lived — the workflow is live and uses a stored secret. It MUST be migrated to OIDC or covered by a logged exception. 
+2. False positive (obsolete file) — the flagged file is no longer in use. It MUST be deleted, not migrated.
+3. Migrated, secrets dormant — the workflow already uses OIDC but old secrets remain in settings. The secrets MUST be deleted and the underlying identity disabled; until then the dormant credential is a live risk. 
+
+Teams MUST follow this resolution sequence for each flagged repository:
+
+1. Confirm whether the file is live or obsolete (delete if obsolete); 
+  1. If live, confirm the mechanism using the id-token: write test; if already OIDC, remove dormant secrets
+  1. If genuinely long-lived, triage need then migrate or log an exception capturing rotation cadence, least-privilege scope, and data-sensitivity / Risk Asset class
+1. Record the verified posture with supporting maintainer confirmation in the remediation log. 
 
 ## 8. Continuous Monitoring of Cloud Authentication Posture
 
+Posture MUST be assessed continuously, not only at a point in time. `moj-github-discovery` runs against the estate and classifies each workflow as oidc, long_lived_credentials, mixed, or none. 
+A scheduled re-scan (tracked under [moj-github-discovery ticket 160](https://github.com/moj-github-discovery/issues/160)) MUST flag new long-lived credential usage and notify the Developer Experience Team.
+Because a point-in-time scan cannot distinguish live from obsolete files or live from dormant secrets, continuous monitoring combined with maintainer verification — not the scan alone — is what produces reliable estate-wide assurance.
+Teams whose workflows are flagged MUST be contacted to migrate, delete an obsolete file, remove dormant secrets, or log an exception.
+
+## Related Standards
+
+This standard is the GitHub-Actions-specific application of MoJ’s wider secrets-management guidance and should be read alongside it.
+The general controls for secret generation, approved secret stores, secret scanning, and incident response are covered by MoJ's secrets-management standard; this standard does not restate them and focuses only on how GitHub Actions workflows authenticate to cloud providers. 
+SHA pinning of third-party actions is covered by MoJ's existing SHA-pinning guidance. 
 
 ## Appendix A - Migration Walkthrough (AWS)
 
-This appendix is informative. It shows the standard AWS migration path; equivalent flows for Azure and GCP are linked in the [References](#references).
+This appendix is informative only. It shows the standard AWS migration path; equivalent flows for Azure and GCP are linked in the [References](#references), as well as cloud-platform and modernisation platform examples.
 
-# 1. Verify the OIDC identity provider is available in the AWS Account. If not, it can be created by the bel
+**1. Provision the OIDC identity provider in your AWS account**
+
+- This should be done once per account utilising the provider URL `https://token.actions.githubusercontent.com`.
+- The audience claim should be set to `sts.amazonaws.com`.
+- If it is absent, raise a request with the account owner.
+
+**2. Create an IAM role for your workflow**
+
+The IAM role should have a trust policy scoped to the repository, branch, and environment that will be using it.
+The role should have a least-privilege policy attached to it, scoped to the resources the workflow needs to access.
+
+```json
+{ 
+    "Version": "2012-10-17", 
+    "Statement": [ 
+        { 
+            "Effect": "Allow", 
+            "Principal": { 
+                "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com" 
+            }, 
+            "Action": "sts:AssumeRoleWithWebIdentity", 
+            "Condition": { 
+                "StringEquals": { 
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com" 
+                }, 
+                "StringLike": { 
+                    "token.actions.githubusercontent.com:sub": "repo:ministryofjustice/YOUR-REPO:ref:refs/heads/main" 
+                } 
+            } 
+        }
+    ] 
+} 
+```
+
+Tighten the sub-claim further where possible, for example to a specific environment or tag.
+
+**3. Attach a least-privilege policy to the role**
+
+Grant only what the workflow needs; do not reuse a policy designed for human users.
+
+**4. Update your workflow to use the OIDC role**
+
+An example workflow snippet is shown below. The `id-token: write` permission is required to mint the OIDC token, and the `role-to-assume` input points to the IAM role created in step 2.
+Ensure all actions are pinned to a full commit SHA, not a branch or tag, to avoid supply-chain compromise.
+
+```yaml
+permissions: 
+    id-token: write 
+    contents: read 
+
+jobs:
+    deploy: 
+        runs-on: ubuntu-latest 
+        steps: 
+            - uses: actions/checkout@<full-commit-sha> 
+            - name: Configure AWS credentials 
+              uses: aws-actions/configure-aws-credentials@<full-commit-sha> 
+              with: 
+                role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }} 
+                aws-region: ${{ vars.AWS_REGION }} 
+            - run: aws sts get-caller-identity 
+```
+
+**5. Validate the Workflow**
+
+Run against a non-production branch first; confirm with `aws sts get-caller-identity` that the assumed role and session permissions are correct.
+
+**6. Remove Old Credentials**
+
+Delete the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secrets and disable or delete the underlying IAM user. 
+This step is the most often forgotten; until it is done the dormant key remains fully exploitable and the migration provides no security benefit. 
 
 ## References
 
@@ -74,3 +255,5 @@ This appendix is informative. It shows the standard AWS migration path; equivale
 - [Microsoft: Authentication vs Authorization](https://learn.microsoft.com/en-us/entra/identity-platform/authentication-vs-authorization)
 - [NCSC cloud security guidance](https://www.ncsc.gov.uk/collection/cloud)
 - [GDS Service Standard](https://www.gov.uk/service-manual/service-standard)
+- [Cloud Platform OIDC Usage Example](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/create.html)
+- [Modernisation Platform OIDC Usage Example](https://user-guide.modernisation-platform.service.justice.gov.uk/user-guide/deploying-your-application.html#deploying-your-application)

--- a/source/standards/github-actions-cloud-authentication.html.md.erb
+++ b/source/standards/github-actions-cloud-authentication.html.md.erb
@@ -1,0 +1,76 @@
+---
+owner_slack: "#developer-experience-team"
+title: GitHub Actions Cloud Authentication Credential Usage
+last_reviewed_on: 2026-07-17
+review_in: 6 months
+---
+
+# GitHub Actions Cloud Authentication Credential Usage
+
+## Summary
+
+To be effective, GitHub Actions workflows that authenticate to a cloud provider must do so without storing long-lived static credentials. 
+This standard defines how all MoJ teams using GitHub Actions in the ministryofjustice organisation must authenticate to AWS, Azure, and GCP, so the organisation has reliable, auditable assurance over its cloud credential posture and teams have a single clear answer to “how should my pipeline authenticate to the cloud?” 
+
+## Requirements
+
+This standard is made up of the following requirements: 
+
+1. [A workflow MUST authenticate via OIDC, not long-lived credentials](#1-authenticating-via-oidc)
+2. [Teams MUST distinguish the identity provider from the credential mechanism](#2-distinguishing-the-identity-provider-from-the-credential-mechanism)
+3. [Workflows MUST set `id-token: write` when using OIDC](#3-workflows-must-set-id-token-write-when-using-oidc)
+4. [Long-lived credentials MUST NOT be used except under a logged exception](#4-long-lived-credentials-must-not-be-used-except-under-a-logged-exception)
+5. [High-blast-radius repositories MUST be classified as Risk Assets](#5-high-blast-radius-repositories-must-be-classified-as-risk-assets)
+6. [Credentials and variables MUST follow the standard naming convention](#6-credentials-and-variables-must-follow-the-standard-naming-convention)
+7. [Flagged repositories MUST be resolved against the verification process](#7-flagged-repositories-must-be-resolved-against-the-verification-process)
+8. [Cloud authentication posture MUST be continuously monitored](#8-cloud-authentication-posture-must-be-continuously-monitored)
+
+## 1. Authenticating via OIDC
+
+GitHub Actions workflows that authenticate to a cloud provider MUST use OpenID Connect (OIDC) federated identity. 
+They MUST NOT use long-lived static credentials (AWS access keys, Azure client secrets, GCP service account keys) stored as repository or organisation secrets, except under a logged exception as set out below.
+
+OIDC exchanges a short-lived signed token for cloud credentials at the moment they are needed. 
+The cloud provider validates the token’s repository, branch, environment and other claims before issuing a session that typically expires within an hour. 
+This is preferred over long-lived credentials for five reasons:
+
+1. **No persistent secret to leak:** Nothing static is stored in GitHub, so a log dump, malicious dependency, or compromised contributor cannot exfiltrate what does not exist. 
+2. **Automatic Expiry:** A leaked token has minutes of utility, not months. 
+3. **Scoped Trust:** The cloud-side trust policy can require specific repository, branch, ref or environment claims; a token issued to a feature branch cannot assume a role intended for main. 
+4. **No Rotation Burden:** There are no keys to rotate, audit, or accidentally let expire. 
+5. **Cleaner audit trail:** Each token exchange is logged with the originating repository and run.
+
+This aligns with the NCSC cloud security guidance principle of minimising the lifetime and blast radius of credentials, and with the GDS Service Standard requirement to manage information risk.
+
+Continued use of long-lived credentials exposes MoJ to credential exfiltration through logs and supply-chain dependencies, stale and over-privileged secrets, lateral movement from leaked keys usable anywhere on the internet, a detection gap where keys surface publicly before they are noticed, and dormant-credential risk where a key left in repository settings after migration remains fully exploitable until deleted.
+
+## 2. Distinguishing the Identity Provider from the Credential Mechanism
+
+## 3. Workflows Using `id-token: write` When Using OIDC
+
+## 4. Exceptions for Long-lived Credentials
+
+## 5. Identifying High-Blast-Radius Repositories
+
+## 6. Credential and Variable Naming Convention
+
+## 7. Flagged Repositories and the Verification Process
+
+## 8. Continuous Monitoring of Cloud Authentication Posture
+
+
+## Appendix A - Migration Walkthrough (AWS)
+
+This appendix is informative. It shows the standard AWS migration path; equivalent flows for Azure and GCP are linked in the [References](#references).
+
+# 1. Verify the OIDC identity provider is available in the AWS Account. If not, it can be created by the bel
+
+## References
+
+- [About security hardening with OpenID Connect ](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
+- [Configuring OpenID Connect in Amazon Web Services](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+- [Azure: Workload identity federation with GitHub Actions ](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-config-app-trust-github)
+- [GCP: Workload Identity Federation with Deployment pipelines](https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines)
+- [Microsoft: Authentication vs Authorization](https://learn.microsoft.com/en-us/entra/identity-platform/authentication-vs-authorization)
+- [NCSC cloud security guidance](https://www.ncsc.gov.uk/collection/cloud)
+- [GDS Service Standard](https://www.gov.uk/service-manual/service-standard)

--- a/source/standards/github-repository-archival.html.md.erb
+++ b/source/standards/github-repository-archival.html.md.erb
@@ -1,0 +1,241 @@
+---
+owner_slack: "#developer-experience-team"
+title: GitHub Repository Archival
+last_reviewed_on: 2026-07-17
+review_in: 6 months
+---
+
+# GitHub Repository Archival
+
+## Executive Summary
+
+**Overview:**
+
+The current GitHub estate contains over 4,000 repositories, with more than half marked as archived. The use of archiving is inconsistent and lacks defined standards. 
+
+The result: 
+
+- Huge volumes of stale repositories,  
+- Possible security risks from public archived repositories with retained secrets, 
+- Reduced visibility of active, maintained services,  
+- Gaps in ownership and governance, 
+- Possible FinOps considerations, 
+- Inappropriately managed services.  
+
+Without a consistent approach, archived repositories may expose risk and generate operational noise. 
+
+**Proposal:**
+
+Introduce a standardised approach to archival across MoJ including: 
+
+- Clear criteria for when a repository should be archived, 
+- A defined archival process, 
+- Security standards to ensure archived repositories are non-operational, 
+- Governance and review standards for compliance management.
+
+**Key Principles:**
+
+This standard is built upon: 
+
+- **Safety first:** archived repositories must not contain active secrets, deployments, integrations, pipelines, workflows, or actions. 
+- **Clarity:** active and inactive repositories should be clearly distinguishable. 
+- **Signals for archival:** archival is based upon a combination of usage, ownership, and operational signals vs arbitrary timelines. 
+- **Controlled lifecycles:** archival/unarchiving should be defined procedures. 
+
+**Key Recommendations:**
+
+- Define and adopt a clear definition for “archived”, 
+- Introduce signal-based criteria to identify archival candidates for review, 
+- Implement a mandatory process: 
+  - Removal of secrets and tokens, 
+  - Disabling workflows and interactions, 
+  - Closure of issues and pull requests. 
+- Default archived repositories to a private visibility, 
+- Introduce regular review cycles to identify candidates and maintain standards, 
+- Consider segregation of archived and active repositories for clarity and governance.
+
+**Key Benefits:**
+
+- Reduced security exposure, 
+- Reduced attack surface, 
+- Improved visibility, 
+- Stronger ownership and governance, 
+- Reduced estate complexity, 
+- Reduced operational overhead, 
+- Potential for FinOps/GreenOps optimisation.
+
+## Context and Problem Statement
+
+The current GitHub estate for the `ministryofjustice` organisation contains approximately:
+
+- 4,600 repositories
+- 2,400 archived repositories (~52%)
+- 1,400 public archived repositories (~30% of total, ~58% of archived)
+
+There is currently no consistent definition of what “archived” means, and the archive flag is applied inconsistently. 
+
+As a result:
+
+- Archived repositories may still contain open issues and pull requests,  
+- Secrets, tokens, integrations, workflows, deployments, and/or pipelines may remain active,  
+- Public archived repositories increase exposure risk,  
+- Ownership is unclear or absent for many repositories,  
+- An unusually large portion of the estate is stale, reducing visibility of active services.
+
+This creates:
+
+- Security risks,
+- Operational noise,
+- Governance and ownership gaps,
+
+## Objectives
+
+This standard aims to introduce a standardised approach to archival including: 
+
+- Defining a clear and consistent standard for repository archival  
+- Establishing signals and criteria for identifying archival candidates  
+- Defining a safe and controlled archival process  
+- Introducing governance and review mechanisms  
+- Reducing estate noise while improving security and clarity  
+
+We must also consider how to implement this incrementally to apply to the current estate.
+
+## Definition of "Archived"
+
+A repository is considered archived when:
+
+> It is no longer actively developed, deployed, or required for operational use, and is retained only for reference, audit, or historical purposes.
+
+An archived repository must be:
+
+- Immutable (no further changes expected – or possible),  
+- Non-executable (no pipelines, deployments, or integrations),  
+- Non-sensitive (no active secrets or credentials)
+- Remain clearly owned (CODEOWNERS must be defined, and a team assigned to the repository).
+
+## Signals of Candidacy for Archival
+
+To monitor candidacy for archival, we should define signal-based criteria to identify and manage archival processes. 
+This proposal focuses on setting the ongoing standards, recommendations for managing the current estate in its existing format will be provided via addendum.
+
+Archival should occur when multiple signals are displayed. All mandatory signals (bold) must be present for archival.
+
+### 1. Activity Signals
+
+- No commits within a period of 12 months, 
+- No recent pull requests, 
+- No active contributors.  
+
+### 2. Operational Signals
+
+- **No active deployments**
+- **No linked environment/namespace**
+- **No CI/CD relevance**
+
+### 3. Usage Signals
+
+- Low/no traffic (clones, views, forks, etc.)
+- **No dependencies (internal or external)**
+
+### 4. Ownership Signals
+
+- **No active owners (CODEOWNERS or team)**
+- Service is retired or replaced by another service
+
+### 5. Edge Cases
+
+Some repositories will trigger a candidacy for archival erroneously.
+In these cases, repositories may be retained as active or classified with adhoc labels to indicate their status. Examples include:
+
+- Libraries infrequently updated but still in use,
+- Infrastructure used only for bootstrapping or initialisation of other services,
+- Template Repositories
+
+## Proposed Archival Process
+
+To remain consistent, an archival process which is repeatable and clearly defined is required broken down into pre-archival checks, security and deactivation, access control, application of status, relocation.
+
+**1. Pre-Archival Checks**
+
+- Confirm usage and mandatory criteria, 
+- Identify current (or candidate) CODEOWNERS, 
+- Verify no downstream consumers, 
+- Triage and close open issues/pull requests,
+- Update README with: 
+    - Archival status, 
+    - Reason for archival, 
+    - Date of archival. 
+
+**2. Security and Deactivation**
+
+- Remove all secrets (AWS, repository, environment), 
+- Revoke any tokens and credentials, 
+- Disable GitHub Actions, 
+- Remove/disable any webhooks and external integrations, 
+- Disable any relevant GitHub Apps, 
+- Decommission in cloud platform. 
+
+**3. Access Control**
+
+- Review visibility and set to private/internal. 
+- Ensure no data is exposed. 
+- Restrict write access. 
+
+**4. Application of Status**
+
+- Apply the GitHub archive flag,
+- Confirm the repository is made read-only,
+
+**5. (Optional) Relocation**
+
+- Move to a dedicated archival organisation
+
+Benefits of relocation to an archive organisation include: 
+
+- Reduced congestion of the primary Ministry of Justice GitHub Organisation, 
+- Clear management and separation of active and inactive services, 
+- Application of stricter governance which can be implemented with greater ease.  
+
+## Archive Management
+
+Archived repositories should be:
+
+- Readable internally, 
+- Not modified, 
+- Not contain integrations of secrets, 
+- Not be in production. 
+
+Should any of this change for any reason, the repository should undergo a formal de-archival process.
+
+## De-Archival Process
+
+This process is recommended as an outline only and should not be common practice. 
+Ultimately, archival should be considered final and irrevocable except in extreme or extenuating circumstances. 
+The following steps must be followed: 
+
+- A clear justification provided,
+- Approval obtained from relevant stakeholders,
+- Ownership assigned (if not already present) or reassigned, 
+- A security review conducted,
+- Pipelines, dependencies, and integrations revalidated,
+- Migrated back to the main organisation.
+
+**Dependency Considerations:**
+
+Before archiving, it must be confirmed if the repository is consumed by other repositories or is used in build or deployment processes. If dependencies exist then consumers must be migrated away, or the repository should remain active and supported. 
+
+**Governance and Ownership:**
+
+All repositories should have a defined owner and where ownership cannot be identified, repositories should be flagged and reviewed.  
+
+For archived repositories ownership may remain with the original team or be transferred to a central governance or platform team depending on the situation. 
+
+**Review and Enforcement:**
+
+An exercise must be regularly undertaken to identify new candidates for archival and review existing archived repositories. It is recommended this is scheduled quarterly with cadence reviewed annually. Whilst a cadence is defined for formal checks, a repository can be migrated to archived at any point, pursuant to relevant criteria being satisfised, by the relevant code owners. 
+
+The following enforcement mechanisms are recommended: 
+
+- Automated reporting to identify repositories with no activity/owner. Archived repositories which do not currently meet archival criteria. 
+- Dashboards (in the developer portal) to create visibility of active and archived repositories alongside compliance with standards. 
+- In conjunction with mandated code owners, teams can be held accountable for inappropriately archived repositories. 


### PR DESCRIPTION
# Introduction :pencil2:

Partially resolves #44 

## Resolution :heavy_check_mark:

- Adds following from SharePoint to devx documentation site, with a view to being published on the portal or the devx-guidance repo to follow

### Runbooks

- Archiving a GitHub Repository - SharePoint:

### Standards

- Archiving a GitHub Repository - SharePoint:
- GitHub Actions OIDC Credential Usage - SharePoint:

## Miscellaneous :heavy_plus_sign:

- Adds pull request template to `.github` folder