### PR TITLE
Add GitHub Repository Guidance documentation

### DIFF
--- a/source/documentation/team-guide/github-repository-guidance.html.md.erb
+++ b/source/documentation/team-guide/github-repository-guidance.html.md.erb
@@ -1,0 +1,28 @@
+---
+owner_slack: "#developer-experience-alerts"
+title: GitHub Repository Guidance
+last_reviewed_on: 2026-07-20
+review_in: 6 months
+---
+
+# GitHub Repository Guidance
+
+This page records the naming convention we have agreed for Developer Experience repositories and how we intend to create and use repositories going forward.
+
+## Naming convention
+
+Repositories owned by the Developer Experience team should use lowercase kebab-case and follow this pattern:
+
+`developer-experience-<product-or-capability>[-<type>]`
+
+The optional suffix can be used when it makes the purpose clearer, for example `api`, `ui`, `docs`, `config`, `infra`, or `template`.
+
+## Repository management
+
+Create repositories per product, service, or distinct capability, and only combine work into a shared repository when it is tightly coupled and delivered as one product.
+
+New repositories should be created via [octo-access](https://github.com/ministryofjustice/octo-access).
+
+The current repository list is maintained on the [OCTO Developer Experience repositories team page](https://github.com/orgs/ministryofjustice/teams/octo-developer-experience/repositories).
+
+This gives us a stable team namespace, makes ownership clearer, and keeps the repo set easy to discover.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -45,6 +45,7 @@ Technical Documentation used and maintained by the Developer Experience Team.
 - [Team Tools](documentation/team-guide/team-tools.html)
 - [Useful Scripts](documentation/team-guide/useful-scripts.html)
 - [Dependabot PR Tracking](documentation/team-guide/dependabot-pr-tracking.html)
+- [GitHub Repository Guidance](documentation/team-guide/github-repository-guidance.html)
 
 ## External User Documentation
 - [External User Documentation](external-user-documentation/index.html)


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/moj-github-discovery/issues/184

## Changes
This pull request adds new documentation to guide the naming and management of GitHub repositories for the Developer Experience team and updates the main documentation index to include this new resource.

**New documentation:**

* Added a new page, `github-repository-guidance.html.md.erb`, outlining the naming convention (lowercase kebab-case), recommended repository structure, and links to relevant tools and team pages for repository creation and management.

**Documentation index update:**

* Updated the main documentation index in `index.html.md.erb` to include a link to the new GitHub Repository Guidance page, making it easier for team members to find and follow the new guidance.
