### PR TITLE
#52: Engineering Platform Dependabot PR Docs Updates

### DIFF
--- a/source/runbooks/github-member-management-workflows-runbook.html.md.erb
+++ b/source/runbooks/github-member-management-workflows-runbook.html.md.erb
@@ -49,7 +49,7 @@ graph LR
 ```
 
 **Token Generation**:
-1. Workflow reads `APP_ID` and `APP_PRIVATE_KEY` from secrets
+1. Workflow reads `APP_CLIENT_ID` and `APP_PRIVATE_KEY` from secrets
 2. Uses `actions/create-github-app-token` to generate a temporary token
 3. Token is valid for 1 hour
 4. Token is scoped to the specific organization
@@ -84,12 +84,12 @@ The Python script (`scripts.add_users_all_org_members_github_team`):
 
 | Secret Name | Type | Description | How to Get |
 |------------|------|-------------|------------|
-| `APP_ID` | Repository Secret | GitHub App ID | From enterprise app settings page |
+| `APP_CLIENT_ID` | Repository Secret | GitHub App Client ID | From enterprise app settings page |
 | `APP_PRIVATE_KEY` | Repository Secret | Private key in PEM format | Generated for the same enterprise app |
 
 The same app credentials are used for both workflows, but the app must be installed in both `ministryofjustice` and `moj-analytical-services` organizations.
 
-Use this enterprise app for `APP_ID` and `APP_PRIVATE_KEY`:
+Use this enterprise app for `APP_CLIENT_ID` and `APP_PRIVATE_KEY`:
 - MOJ GitHub Users Sync App
 
 **Adding Secrets**:
@@ -179,10 +179,10 @@ The GitHub App must have these permissions:
 Error: Bad credentials
 ```
 
-**Cause**: APP_ID or APP_PRIVATE_KEY is incorrect
+**Cause**: APP_CLIENT_ID or APP_PRIVATE_KEY is incorrect
 
 **Solution**:
-1. Verify APP_ID matches the app settings page
+1. Verify APP_CLIENT_ID matches the app settings page
 2. Regenerate private key and update secret
 3. Ensure entire PEM file was copied (including BEGIN/END lines)
 
@@ -272,10 +272,10 @@ Error: The job running on runner has exceeded the maximum execution time of X mi
    # In workflow file, add debug step:
    - name: Debug
      run: |
-       echo "APP_ID length: ${#APP_ID}"
+       echo "APP_CLIENT_ID length: ${#APP_CLIENT_ID}"
        echo "Key length: ${#APP_PRIVATE_KEY}"
      env:
-       APP_ID: ${{ secrets.APP_ID }}
+       APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
        APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
    ```
 


### PR DESCRIPTION
Updates `github-member-management-workflows-runbook` with `APP_ID` -> `APP_CLIENT_ID` to reflect `app-id` -> `client-id` deprecation as observed in https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/pull/54