### PR TITLE
#407 Fix Dev Portal Feedback Link (Documentation)

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -29,6 +29,7 @@ Technical Documentation used and maintained by the Developer Experience Team.
 - [SSO Architecture Runbook](runbooks/sso-architecture.html)
 - [Portal Testing Runbook](runbooks/testing-developer-portal.html)
 - [GitHub to XSIAM Logging Integration](runbooks/github-xsiam-logging-integration.html)
+- [PostHog Runbook](runbooks/posthog-runbook.html)
 
 ## POC/Discovery/Spike Findings
 

--- a/source/runbooks/posthog-runbook.html.md.erb
+++ b/source/runbooks/posthog-runbook.html.md.erb
@@ -1,0 +1,25 @@
+---
+owner_slack: "#developer-experience-alerts"
+title: PostHog runbook
+last_reviewed_on: 2026-08-10
+review_in: 6 months
+---
+
+# Posthog Runbook
+
+PostHog is a tool that allows us to capture and analyse user behaviour. This runbook covers useful information on how to use PostHog.
+
+## Dashboard
+
+A dashboard is a customisable collection of insights, widgets and text, allowing you to view data in one place.
+Dashboards can be created and edited by going to `Project > Tools > Dashboards` in the PostHog website.
+
+## Surveys
+
+Surveys ask users questions and allow them to submit their feedback. Responses are saved and can be viewed in the PostHog dashboard.
+Popover surveys appear over the content of the page and can be triggered by specific events. Responses can also be sent to a survey via the PostHog API.
+
+### Seeing Survey Responses
+
+Responses can be viewed inside the PostHog website by going to `Project > Tools > Surveys` and selecting the survey you would like to see the responses for.
+They can also be added to a Dashboard as a widget to visualise the feedback alongside other insights.


### PR DESCRIPTION
# Introduction :pencil2:

Partially solves [ministry-of-justice/ministry-of-justice-developer-portal#407](https://github.com/ministryofjustice/ministry-of-justice-developer-portal/issues/407) by adding documentation for how to access the responses to surveys in PostHog. Also adds some basic information for how we use PostHog to be built upon as we continue to use it.

## Resolution :heavy_check_mark:

List all changes made to the codebase.
- Added `source/runbooks/posthog-runbook` with brief introduction to how we use Posthog
- Updated `source/index` to add runbook to the list