### PR TITLE
Add dev container Golden Path runbook

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,6 +30,7 @@ Technical Documentation used and maintained by the Developer Experience Team.
 - [Portal Testing Runbook](runbooks/testing-developer-portal.html)
 - [GitHub to XSIAM Logging Integration](runbooks/github-xsiam-logging-integration.html)
 - [PostHog Runbook](runbooks/posthog-runbook.html)
+- [Dev Container Golden Path Runbook](runbooks/dev-container-golden-path-runbook.html)
 
 ## POC/Discovery/Spike Findings
 

--- a/source/runbooks/dev-container-golden-path-runbook.html.md.erb
+++ b/source/runbooks/dev-container-golden-path-runbook.html.md.erb
@@ -30,6 +30,7 @@ flowchart LR
 
 - Docker as the container engine
 - Podman also works: tested MOJ base image pull, features, workspace mount, post-create script
+- Visual Studio Code with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), or the [devcontainer CLI](https://github.com/devcontainers/cli) if working from the terminal
 
 ## What this runbook consists of
 
@@ -98,6 +99,8 @@ Only applies if the relevant file exists in the repository.
 Copy and customise these files for your repository.
 
 ### devcontainer.json
+
+Find the current base image tag at [ghcr.io/ministryofjustice/devcontainer-base](https://github.com/ministryofjustice/.devcontainer/pkgs/container/devcontainer-base).
 
 ````json
 {

--- a/source/runbooks/dev-container-golden-path-runbook.html.md.erb
+++ b/source/runbooks/dev-container-golden-path-runbook.html.md.erb
@@ -1,0 +1,174 @@
+---
+owner_slack: "#devcontainer-community"
+title: Dev container Golden Path runbook
+last_reviewed_on: 2026-08-12
+review_in: 6 months
+---
+
+# Setting up a dev container for your repository - Golden Path runbook
+
+
+Use a dev container to get a consistent, ready-to-use development environment for any MOJ GitHub repository.
+
+## Overview
+
+````mermaid
+flowchart LR
+    A[Read the runbook] --> B[Understand the checklist<br/>and your repo's prerequisites]
+    B --> C[Copy the template files<br/>and edit to fit your repo]
+    C --> D[Test and commit]
+````
+
+## Why use this runbook
+
+- less time to ship a working dev container environment for your repository
+- use the shared Ministry of Justice base image `ghcr.io/ministryofjustice/devcontainer-base:TAG_HERE` rather than writing a custom Dockerfile
+- automatic access to security updates maintained on the base image
+- a consistent environment across MOJ repositories
+
+## Prerequisites
+
+- Docker as the container engine.
+- Podman also works: tested MOJ base image pull, features, workspace mount, post-create script.
+
+## What this runbook consists of
+
+- `.devcontainer/devcontainer.json` - defines the base image, features and setup command
+- `.devcontainer/post-create.sh` - runs once when the container is built, installs tools not covered by a feature
+- `.devcontainer/README.md` - short usage note for contributors
+
+## Checklist - complete before writing any files
+
+### 1. What does the repository actually need
+
+- [ ] Check for `pyproject.toml`, `requirements.txt`, `Pipfile` - confirms Python and which package manager
+- [ ] Check for `package.json` - confirms Node and which package manager
+- [ ] Check `.github/workflows/*.yml` for the language versions and tools CI actually installs and runs
+- [ ] Check the `Makefile` or equivalent for local task commands (for example `make check`)
+- [ ] Confirm whether the repository has any Terraform, AWS, or Kubernetes code
+
+### 2. Which of the features apply
+
+Check there is real evidence a feature is needed, not just that it is available.
+
+| Feature | Only include if |
+|---|---|
+| apm | Repository needs Microsoft's Agent Package Manager CLI |
+| astral | Repository uses `uv` or `ruff` |
+| aws | Repository interacts with AWS directly (not just hosted there) |
+| cloud-platform | Repository is deployed to MOJ Cloud Platform |
+| container-structure-test | Repository builds and tests container images (also pulls in the community `docker-in-docker` feature) |
+| kubernetes | Repository manages Kubernetes manifests or Helm charts directly |
+| static-analysis | Repository contains infrastructure-as-code to scan |
+| terraform | Repository contains Terraform code |
+
+`cloud-platform` automatically pulls in `kubernetes` with `kubectl` pinned to a specific version. Do not add `kubernetes` separately unless you understand this.
+
+### 3. Using features not in the MOJ list
+
+For language runtimes and general tools, for example Python, Node, use the community features directory instead: containers.dev/features.
+
+Community features are referenced the same way as MOJ features, just with a different registry path:
+
+````json
+"features": {
+  "ghcr.io/devcontainers/features/python:1": { "version": "3.11" },
+  "ghcr.io/ministryofjustice/devcontainer-feature/astral:1": {}
+}
+````
+
+You can mix MOJ and community features in the same `features` block.
+
+### 4. Cross-check for inconsistency
+
+Only applies if the relevant file exists in the repository.
+
+- [ ] If a `package.json` exists, does its engines field match what a dependency actually needs?
+- [ ] Does a CI workflow install a different tool version than what's declared elsewhere?
+- [ ] Is a tool referenced in setup that CI does not actually use?
+
+### 5. Before you commit
+
+- [ ] Run the generated `devcontainer.json` locally with `devcontainer up`
+- [ ] Confirm `post-create.sh` completes without error
+- [ ] Confirm any tool installed locally matches the version CI uses
+
+## Template files
+
+Copy and customise these files for your repository.
+
+### devcontainer.json
+
+````json
+{
+  "name": "REPO_NAME_HERE",
+  "image": "ghcr.io/ministryofjustice/devcontainer-base:TAG_HERE",
+  "features": {
+    // Add only the features this repository needs.
+    // See the checklist above before choosing any.
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": []
+    }
+  }
+}
+````
+
+### post-create.sh
+
+````bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Dev container setup starting"
+
+# Add setup steps here based on the checklist above.
+# Pin any downloaded tool version and verify with a checksum where possible.
+
+echo "Dev container setup complete"
+````
+
+### README.md
+
+````markdown
+# Dev container
+
+This repository uses a dev container for local development.
+
+## Prerequisites
+
+- Docker, or Podman
+- Visual Studio Code
+  - [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+## Getting started
+
+To launch locally, ensure the prerequisites are met, then select "Reopen in Container" when prompted, or run:
+
+```bash
+devcontainer up --workspace-folder .
+```
+
+Prefer the terminal, or a different editor? Use the [devcontainer CLI](https://github.com/devcontainers/cli) directly, no VS Code required.
+
+## What's inside
+
+- Base image: `ghcr.io/ministryofjustice/devcontainer-base:TAG_HERE` — replace `TAG_HERE` with the current version tag
+- The shared Ministry of Justice base image, maintained by the Dev Container Community of Practice.
+- Runs as a non-root `vscode` user by design.
+````
+
+## Support
+
+If you need help, post in [#devcontainer-community](https://moj.enterprise.slack.com/archives/C06DZ4F04JZ) or leave feedback in [#ask-developer-experience](https://moj.enterprise.slack.com/archives/C0AJBK3P5A8).
+
+
+## For reference
+
+- [moj-github-discovery](https://github.com/ministryofjustice/moj-github-discovery/tree/main/.devcontainer)
+- [Octo Access](https://github.com/ministryofjustice/octo-access/tree/main/.devcontainer)
+- [modernisation-platform-environments](https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/.devcontainer)
+- [ministry-of-justice/.devcontainer](https://github.com/ministryofjustice/.devcontainer)
+    

--- a/source/runbooks/dev-container-golden-path-runbook.html.md.erb
+++ b/source/runbooks/dev-container-golden-path-runbook.html.md.erb
@@ -5,10 +5,10 @@ last_reviewed_on: 2026-08-12
 review_in: 6 months
 ---
 
-# Setting up a dev container for your repository - Golden Path runbook
+# Setting up a dev container for your repository - golden path runbook
 
 
-Use a dev container to get a consistent, ready-to-use development environment for any MOJ GitHub repository.
+Use a dev container to get a consistent, ready-to-use development environment for any Ministry of Justice (**MOJ**) GitHub repository.
 
 ## Overview
 
@@ -28,8 +28,8 @@ flowchart LR
 
 ## Prerequisites
 
-- Docker as the container engine.
-- Podman also works: tested MOJ base image pull, features, workspace mount, post-create script.
+- Docker as the container engine
+- Podman also works: tested MOJ base image pull, features, workspace mount, post-create script
 
 ## What this runbook consists of
 
@@ -39,36 +39,36 @@ flowchart LR
 
 ## Checklist - complete before writing any files
 
-### 1. What does the repository actually need
+### What does the repository actually need
 
-- [ ] Check for `pyproject.toml`, `requirements.txt`, `Pipfile` - confirms Python and which package manager
-- [ ] Check for `package.json` - confirms Node and which package manager
-- [ ] Check `.github/workflows/*.yml` for the language versions and tools CI actually installs and runs
-- [ ] Check the `Makefile` or equivalent for local task commands (for example `make check`)
-- [ ] Confirm whether the repository has any Terraform, AWS, or Kubernetes code
+- [ ] check for `pyproject.toml`, `requirements.txt`, `Pipfile` - confirms Python and which package manager
+- [ ] check for `package.json` - confirms Node and which package manager
+- [ ] check `.github/workflows/*.yml` for the language versions and tools CI actually installs and runs
+- [ ] check the `Makefile` or equivalent for local task commands (for example `make check`)
+- [ ] confirm whether the repository has any Terraform, AWS, or Kubernetes code
 
-### 2. Which of the features apply
+### Which of the features apply
 
 Check there is real evidence a feature is needed, not just that it is available.
 
 | Feature | Only include if |
 |---|---|
-| apm | Repository needs Microsoft's Agent Package Manager CLI |
-| astral | Repository uses `uv` or `ruff` |
-| aws | Repository interacts with AWS directly (not just hosted there) |
-| cloud-platform | Repository is deployed to MOJ Cloud Platform |
-| container-structure-test | Repository builds and tests container images (also pulls in the community `docker-in-docker` feature) |
-| kubernetes | Repository manages Kubernetes manifests or Helm charts directly |
-| static-analysis | Repository contains infrastructure-as-code to scan |
-| terraform | Repository contains Terraform code |
+| apm | repository needs Microsoft's Agent Package Manager CLI |
+| astral | repository uses `uv` or `ruff` |
+| aws | repository interacts with AWS directly (not just hosted there) |
+| cloud-platform | repository is deployed to MOJ Cloud Platform |
+| container-structure-test | repository builds and tests container images (also pulls in the community `docker-in-docker` feature) |
+| kubernetes | repository manages Kubernetes manifests or Helm charts directly |
+| static-analysis | repository contains infrastructure-as-code to scan |
+| terraform | repository contains Terraform code |
 
 `cloud-platform` automatically pulls in `kubernetes` with `kubectl` pinned to a specific version. Do not add `kubernetes` separately unless you understand this.
 
-### 3. Using features not in the MOJ list
+### Using features not in the MOJ list
 
 For language runtimes and general tools, for example Python, Node, use the community features directory instead: containers.dev/features.
 
-Community features are referenced the same way as MOJ features, just with a different registry path:
+Community features are referenced the same way as MOJ features, just with a different registry path.
 
 ````json
 "features": {
@@ -79,19 +79,19 @@ Community features are referenced the same way as MOJ features, just with a diff
 
 You can mix MOJ and community features in the same `features` block.
 
-### 4. Cross-check for inconsistency
+### Cross-check for inconsistency
 
 Only applies if the relevant file exists in the repository.
 
-- [ ] If a `package.json` exists, does its engines field match what a dependency actually needs?
-- [ ] Does a CI workflow install a different tool version than what's declared elsewhere?
-- [ ] Is a tool referenced in setup that CI does not actually use?
+- [ ] if a `package.json` exists, does its engines field match what a dependency actually needs?
+- [ ] does a CI workflow install a different tool version than what's declared elsewhere?
+- [ ] is a tool referenced in setup that CI does not actually use?
 
-### 5. Before you commit
+### Before you commit
 
-- [ ] Run the generated `devcontainer.json` locally with `devcontainer up`
-- [ ] Confirm `post-create.sh` completes without error
-- [ ] Confirm any tool installed locally matches the version CI uses
+- [ ] run the generated `devcontainer.json` locally with `devcontainer up`
+- [ ] confirm `post-create.sh` completes without error
+- [ ] confirm any tool installed locally matches the version CI uses
 
 ## Template files
 
@@ -156,7 +156,7 @@ Prefer the terminal, or a different editor? Use the [devcontainer CLI](https://g
 ## What's inside
 
 - Base image: `ghcr.io/ministryofjustice/devcontainer-base:TAG_HERE` — replace `TAG_HERE` with the current version tag
-- The shared Ministry of Justice base image, maintained by the Dev Container Community of Practice.
+- The shared MOJ base image, maintained by the Dev Container Community of Practice.
 - Runs as a non-root `vscode` user by design.
 ````
 


### PR DESCRIPTION
# Introduction :pencil2:

Adds the Golden Path runbook for setting up a dev container in a MOJ repository, based on findings and testing from #294 and #295.
## Resolution :heavy_check_mark:

- Added source/runbooks/dev-container-golden-path-runbook.html.md.erb, covering prerequisites, a checklist of what to check per-repo, the  MOJ features and when to use them, template files (devcontainer.json, post-create.sh, README.md), and reference links to existing MOJ repos using dev containers
- Added the runbook to the Runbooks list in source/index.html.md.erb

## Miscellaneous :heavy_plus_sign:

- Confirmed Podman as a working alternative to Docker for this pattern, base image pull, features, workspace mount, and post-create script all tested successfully.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

Add screenshots here.
<img width="1794" height="1021" alt="image" src="https://github.com/user-attachments/assets/79365743-0762-4747-938a-d6cf38561e51" />

</details>
